### PR TITLE
DEV-539 - Make statement File/Text extract easily aceessible to Interpreters 

### DIFF
--- a/app/components/meetings/sessions/files-view.vue
+++ b/app/components/meetings/sessions/files-view.vue
@@ -6,7 +6,7 @@
         <div v-for=" {language, text, contentType, url, public: isPublic, allowPublic, _id} in files" v-bind:key="_id" >
           <span class="d-none d-md-inline">
             <a @click="showPreview(text, language)" :style="{ visibility: (text?'visible':'hidden') }" :class="{ 'btn btn-lg btn-outline-dark': showPreviewAsButton}">
-              <i :style="{ visibility: (text?'visible':'hidden') }" class="fa fa-file-text-o" aria-hidden="true"></i>
+              <i class="fa fa-file-text-o" aria-hidden="true"></i>
             </a>
             <a target="_blank" :href="url">
               <i :class="[getMimeConfig(contentType).icon, getMimeConfig(contentType).color]" class="fa"/>

--- a/app/components/meetings/sessions/files-view.vue
+++ b/app/components/meetings/sessions/files-view.vue
@@ -4,9 +4,10 @@
     <!-- Medium view and above -->
     <div class="document-files">
         <div v-for=" {language, text, contentType, url, public: isPublic, allowPublic, _id} in files" v-bind:key="_id" >
-
           <span class="d-none d-md-inline">
-            <i :style="{ visibility: (text?'visible':'hidden') }" class="fa fa-file-text-o" aria-hidden="true" @click="showPreview(text, language)"></i>
+            <a @click="showPreview(text, language)" :style="{ visibility: (text?'visible':'hidden') }" :class="{ 'btn': showPreviewAsButton, 'btn-lg': showPreviewAsButton, 'btn-outline-dark': showPreviewAsButton }">
+              <i :style="{ visibility: (text?'visible':'hidden') }" class="fa fa-file-text-o" aria-hidden="true"></i>
+            </a>
             <a target="_blank" :href="url">
               <i :class="[getMimeConfig(contentType).icon, getMimeConfig(contentType).color]" class="fa"/>
                 <span class="language">
@@ -55,7 +56,8 @@ const   MIMES = {
 export default {
   name    :  'FilesView',
   props   : {
-              files: { type: Object, required: false }
+              files: { type: Object, required: false },
+              showPreviewAsButton: { type: Boolean, default: false }
             },
   methods : { getMimeConfig, showPreview },
   filters : { langTextFilter },
@@ -95,6 +97,10 @@ function getMimeConfig(mimeType){
 .document-files {
   text-align: left;
   padding-left: 25px;
-} 
+}
+
+.btn-outline-dark:hover {
+  color: #fff !important;
+}
 
 </style>

--- a/app/components/meetings/sessions/files-view.vue
+++ b/app/components/meetings/sessions/files-view.vue
@@ -5,7 +5,7 @@
     <div class="document-files">
         <div v-for=" {language, text, contentType, url, public: isPublic, allowPublic, _id} in files" v-bind:key="_id" >
           <span class="d-none d-md-inline">
-            <a @click="showPreview(text, language)" :style="{ visibility: (text?'visible':'hidden') }" :class="{ 'btn': showPreviewAsButton, 'btn-lg': showPreviewAsButton, 'btn-outline-dark': showPreviewAsButton }">
+            <a @click="showPreview(text, language)" :style="{ visibility: (text?'visible':'hidden') }" :class="{ 'btn btn-lg btn-outline-dark': showPreviewAsButton}">
               <i :style="{ visibility: (text?'visible':'hidden') }" class="fa fa-file-text-o" aria-hidden="true"></i>
             </a>
             <a target="_blank" :href="url">

--- a/app/components/meetings/sessions/interpreters-view.vue
+++ b/app/components/meetings/sessions/interpreters-view.vue
@@ -28,7 +28,7 @@
 
     <div class="card mb-3" v-if="interventions.length">
       <Session>
-        <InterventionRow class="interpreter-view" :class="{ 'table-secondary': intervention.files[0].language!=='en' }" v-for="(intervention, index) in interventions" v-bind="{intervention, index}" v-bind:key="intervention._id"/>
+        <InterventionRow class="interpreter-view" :class="{ 'table-secondary': intervention.files[0].language!=='en' }" v-for="(intervention, index) in interventions" v-bind="{intervention, index}" v-bind:key="intervention._id" :show-preview-as-button="true" />
       </Session>
     </div>
   

--- a/app/components/meetings/sessions/intervention-row.vue
+++ b/app/components/meetings/sessions/intervention-row.vue
@@ -35,8 +35,6 @@
           </span>
         </div>
 
-        {{ showPreviewAsButton }}
-
         <slot>
             <FilesPreview v-if="isPending(intervention.status)" :files="intervention.files"/>
         </slot>

--- a/app/components/meetings/sessions/intervention-row.vue
+++ b/app/components/meetings/sessions/intervention-row.vue
@@ -35,9 +35,10 @@
           </span>
         </div>
 
+        {{ showPreviewAsButton }}
 
         <slot>
-            <FilesPreview v-if="isPending(intervention.status)" :files="intervention.files" />
+            <FilesPreview v-if="isPending(intervention.status)" :files="intervention.files"/>
         </slot>
 
         <div>
@@ -49,7 +50,7 @@
     </td>
 
     <td class="files-col" style="text-align: center; vertical-align: middle;">
-        <FilesView :files="intervention.files"/>
+        <FilesView :files="intervention.files" :show-preview-as-button="showPreviewAsButton"/>
     </td>
 
     <td class="controls-col" >
@@ -78,6 +79,7 @@ export default {
                   showTime    : { type: Boolean, required: false, default: true },
                   publicView  : { type: Boolean, required: false, default: false },
                   timezone    : { type: String,  required: false, default: 'local' },
+                  showPreviewAsButton : { type: Boolean, default: false }
               },
   methods   : { getOrgType, isPending },
   filters   : { formatDate, setTimezone },


### PR DESCRIPTION
### General description
Improving accessibility on interpreter screen to allow easy access to text extract for interpreters when using tablet/phone devices.

### Designs
N/A

### Testing instructions
- Access the interpreter panel (https://www.cbddev.xyz/conferences/nairobi-2023/interpreter-panel).
- Next to the download document button, the text extract icon should appear larger with a darker border.
- The icon will change only on this page, on all the other pages the icon will remain as it was before.

## Checklist before merging
* [X]  Branch name / PR includes the related Jira ticket Id.
* [X]  Tests to check core implementation / bug fix added.
* [X]  All checks in Continuous Integration workflow pass.
* [ ]  Feature functionally tested by reviewer(s).
* [ ]  Code reviewed by reviewer(s).
* [X]  Documentation updated (README, CHANGELOG...) (if required)