### PR TITLE
Fix margin on p is set to parent (0px)

### DIFF
--- a/app/directives/articles/cbd-article.html
+++ b/app/directives/articles/cbd-article.html
@@ -4,11 +4,6 @@
             /* padding-top: 15px; */
         }
 
-        .ck-content p {
-            margin-top: inherit!important;
-            margin-bottom: inherit!important;
-        }
-
         .ck-content .table th, .table td {
            vertical-align: inherit;
         }


### PR DESCRIPTION
DRAFT- TO BE DISCUSSED There is no margin between paragraph because of this.  This break the notification. so overcome the problem editors use to put 2 returns.

Problem visible in notifications.

This will require to reprocess all article based notification to remove the extra empty p's 
```html
<p>&nbsp;</p>
```
