### PR TITLE
Updates Kronos publish URL

### DIFF
--- a/app/views/kronos/index.html
+++ b/app/views/kronos/index.html
@@ -21,7 +21,7 @@
             <br> <i class="fa fa-hourglass-half" aria-hidden="true"></i> Access Kronos Web<br>&nbsp;
         </a>
 
-        <a href="https://secure.cbd.int/kronos/app/publish.htm"class="btn btn-default btn-lg">
+        <a href="https://kronos.cbd.int/app/publish.htm"class="btn btn-default btn-lg">
             <br><i class="fa fa-arrow-circle-down" aria-hidden="true"></i> Install the Kronos Windows Application <br>&nbsp;
         </a>
             


### PR DESCRIPTION
Updates the URL for installing the Kronos Windows application to point to the new deplayment servers.

Depends on: https://github.com/scbd/kronos/pull/92