### PR TITLE
Adds datetime parameter to schedule retrieval

### DIFF
--- a/app/views/meetings/documents/agenda.js
+++ b/app/views/meetings/documents/agenda.js
@@ -537,7 +537,7 @@ export default ["$scope", "$route", "$http", '$q', '$interval', 'conferenceServi
             _ctrl.types[0].loaded = false;
             _ctrl.currentTab = undefined;
 
-            $location.search({ datetime: date });
+            $location.search({ datetime: date, timezone: getTimezone() });
 
             load();
             _ctrl.currentTab = tab;

--- a/app/views/schedules/index-id.js
+++ b/app/views/schedules/index-id.js
@@ -51,12 +51,13 @@ export default ['$scope', '$http', '$route', '$q', 'streamId', 'conferenceServic
 
             const expandedReservationIds = _(_ctrl.frames).map(f=>f.reservations||[]).flatten().filter(r=>r.expand).map(r=>r._id).value();
 
-            const dateTimeString = $route.current.params.datetime || $location.search().datetime; 
-            const dateTime       = dateTimeString ? moment.tz(dateTimeString, getTimezone()).startOf('day').toISOString() : null;
-            var streamId         = $route.current.params.streamId || defaultStreamId;
+            const timezone      = $route.current.params?.timezone || $location.search()?.timezone || getTimezone();
+            const dateTimeSting = $route.current.params?.datetime || $location.search()?.datetime; 
+            const dateTime      = dateTimeSting ? moment.tz(dateTimeSting, timezone).startOf('day').toISOString() : null;
+            const streamId      = $route.current.params.streamId || defaultStreamId;
 
-            var options  = dateTime ? { params : { cache:true, datetime: dateTime } } : { params : { cache:true } };
-         
+            const options  = dateTime ? { params : { cache:true, datetime:dateTime } } : { params : { cache:true } };
+
             return $q.when().then(async function(code){
 
                 const url = _ctrl.all
@@ -230,7 +231,7 @@ export default ['$scope', '$http', '$route', '$q', 'streamId', 'conferenceServic
         }
 
         function getTimezone() {
-          return  _ctrl.conferenceTimezone 
+            return $route.current.params?.timezone || $location.search()?.timezone || _ctrl.conferenceTimezone
         }
         _ctrl.getTimezone = getTimezone
 


### PR DESCRIPTION
Adds a datetime parameter to the schedule retrieval process,
allowing users to view schedules for specific dates.  This
addresses an issue where the schedule was not correctly
displaying past dates due to a timezone issue. It obtains the datetime from the URL parameters.
