### PR TITLE
Bug/schedule datetime

### DIFF
--- a/app/views/schedules/index-id.js
+++ b/app/views/schedules/index-id.js
@@ -51,8 +51,11 @@ export default ['$scope', '$http', '$route', '$q', 'streamId', 'conferenceServic
 
             const expandedReservationIds = _(_ctrl.frames).map(f=>f.reservations||[]).flatten().filter(r=>r.expand).map(r=>r._id).value();
 
-            var streamId = $route.current.params.streamId || defaultStreamId;
-            var options  = { params : { cache:true } };
+            const dateTimeSting = $route.current.params.datetime || $location.search().datetime; 
+            const dateTime      = dateTimeSting ? moment.tz(dateTimeSting, getTimezone()).startOf('day').add(1, 'days').toISOString() : null;
+            var streamId        = $route.current.params.streamId || defaultStreamId;
+
+            var options  = dateTime ? { params : { cache:true, datetime: dateTime } } : { params : { cache:true } };
          
             return $q.when().then(async function(code){
 

--- a/app/views/schedules/index-id.js
+++ b/app/views/schedules/index-id.js
@@ -51,9 +51,9 @@ export default ['$scope', '$http', '$route', '$q', 'streamId', 'conferenceServic
 
             const expandedReservationIds = _(_ctrl.frames).map(f=>f.reservations||[]).flatten().filter(r=>r.expand).map(r=>r._id).value();
 
-            const dateTimeSting = $route.current.params.datetime || $location.search().datetime; 
-            const dateTime      = dateTimeSting ? moment.tz(dateTimeSting, getTimezone()).startOf('day').toISOString() : null;
-            var streamId        = $route.current.params.streamId || defaultStreamId;
+            const dateTimeString = $route.current.params.datetime || $location.search().datetime; 
+            const dateTime       = dateTimeString ? moment.tz(dateTimeString, getTimezone()).startOf('day').toISOString() : null;
+            var streamId         = $route.current.params.streamId || defaultStreamId;
 
             var options  = dateTime ? { params : { cache:true, datetime: dateTime } } : { params : { cache:true } };
          

--- a/app/views/schedules/index-id.js
+++ b/app/views/schedules/index-id.js
@@ -52,7 +52,7 @@ export default ['$scope', '$http', '$route', '$q', 'streamId', 'conferenceServic
             const expandedReservationIds = _(_ctrl.frames).map(f=>f.reservations||[]).flatten().filter(r=>r.expand).map(r=>r._id).value();
 
             const dateTimeSting = $route.current.params.datetime || $location.search().datetime; 
-            const dateTime      = dateTimeSting ? moment.tz(dateTimeSting, getTimezone()).startOf('day').add(1, 'days').toISOString() : null;
+            const dateTime      = dateTimeSting ? moment.tz(dateTimeSting, getTimezone()).startOf('day').toISOString() : null;
             var streamId        = $route.current.params.streamId || defaultStreamId;
 
             var options  = dateTime ? { params : { cache:true, datetime: dateTime } } : { params : { cache:true } };


### PR DESCRIPTION
This pull request introduces a minor enhancement to the schedule loading logic by allowing filtering based on a specific date and time. If a `datetime` parameter is provided in the route or query string, the backend request will include this date, enabling more precise schedule retrieval.

* Schedule filtering enhancement:
  * Updated the options object in `app/views/schedules/index-id.js` to include a `datetime` parameter when present, allowing for date-specific schedule queries.
  
  https://www.cbd.int/conferences/rome-2026/schedules?datetime=2026-02-19
  
  https://www.cbd.int/conferences/rome-2026/schedules?datetime=2026-02-16