### PR TITLE
DEV-840 - Updates Kronos user access role

### DIFF
--- a/app/routes/kronos.js
+++ b/app/routes/kronos.js
@@ -12,7 +12,7 @@ app.config(['$routeProvider', '$locationProvider', function($routeProvider, $loc
 
     $routeProvider
     .when('/',                     { ...mapView(indexView),          controllerAs: 'indexCtrl',         resolve: { user : currentUser() }  })
-    .when('/media-requests',       { ...mapView(angularViewWrapper), controllerAs: 'mediaRequestCtrl',  resolve: { component:()=>import('~/views/kronos/media-requests/index'),       user : securize(["Administrator","Kronos-FullAccess","SCBDMedia"]) }  })
-    .when('/media-requests/:code', { ...mapView(angularViewWrapper), controllerAs: 'mediaRequestCtrl',  resolve: { component:()=>import('~/views/kronos/media-requests/index'),       user : securize(["Administrator","Kronos-FullAccess","SCBDMedia"]) }  })
+    .when('/media-requests',       { ...mapView(angularViewWrapper), controllerAs: 'mediaRequestCtrl',  resolve: { component:()=>import('~/views/kronos/media-requests/index'),       user : securize(["Administrator","Kronos-User","SCBDMedia"]) }  })
+    .when('/media-requests/:code', { ...mapView(angularViewWrapper), controllerAs: 'mediaRequestCtrl',  resolve: { component:()=>import('~/views/kronos/media-requests/index'),       user : securize(["Administrator","Kronos-User","SCBDMedia"]) }  })
     .otherwise({redirectTo: '/404'});
 }]);

--- a/app/routes/kronos.js
+++ b/app/routes/kronos.js
@@ -13,6 +13,6 @@ app.config(['$routeProvider', '$locationProvider', function($routeProvider, $loc
     $routeProvider
     .when('/',                     { ...mapView(indexView),          controllerAs: 'indexCtrl',         resolve: { user : currentUser() }  })
     .when('/media-requests',       { ...mapView(angularViewWrapper), controllerAs: 'mediaRequestCtrl',  resolve: { component:()=>import('~/views/kronos/media-requests/index'),       user : securize(["Administrator","Kronos-User","SCBDMedia"]) }  })
-    .when('/media-requests/:code', { ...mapView(angularViewWrapper), controllerAs: 'mediaRequestCtrl',  resolve: { component:()=>import('~/views/kronos/media-requests/index'),       user : securize(["Administrator","Kronos-User","SCBDMedia"]) }  })
+    .when('/media-requests/:code', { ...mapView(angularViewWrapper), controllerAs: 'mediaRequestCtrl',  resolve: { component:()=>import('~/views/kronos/media-requests/index'),       user : securize(["Administrator", "Kronos-FullAccess", "Kronos-User","SCBDMedia"]) }  })
     .otherwise({redirectTo: '/404'});
 }]);

--- a/app/views/kronos/index.js
+++ b/app/views/kronos/index.js
@@ -2,5 +2,5 @@ export { default as template } from './index.html'
 
 export default ['user', function(user) {
   this.isAuthenticated = user.isAuthenticated;
-  this.isKronosUser    = user.institution=='CBD' && user.roles.includes('Kronos-FullAccess');
+  this.isKronosUser    = user.institution=='CBD' && user.roles.includes('Kronos-User');
 }];

--- a/app/views/kronos/index.js
+++ b/app/views/kronos/index.js
@@ -2,5 +2,5 @@ export { default as template } from './index.html'
 
 export default ['user', function(user) {
   this.isAuthenticated = user.isAuthenticated;
-  this.isKronosUser    = user.institution=='CBD' && user.roles.includes('Kronos-User');
+  this.isKronosUser    = user.institution=='CBD' && (user.roles.includes('Kronos-User') || user.roles.includes('Kronos-FullAccess'));
 }];


### PR DESCRIPTION
Adds support for both `Kronos-User` and `Kronos-FullAccess` roles for media request route security and Kronos user identification logic. This change ensures backward compatibility with the legacy `Kronos-FullAccess` role while standardizing on `Kronos-User` as the primary role.

- `isKronosUser` now returns `true` for users with either `Kronos-User` or `Kronos-FullAccess` role (institution must still be `CBD`)
- The `/media-requests/:code` route accepts both `Kronos-FullAccess` and `Kronos-User` in addition to `Administrator` and `SCBDMedia`

Relates to DEV-840