### PR TITLE
Fix: Handle empty media request list gracefully

### DIFF
--- a/app/views/kronos/media-requests/index.html
+++ b/app/views/kronos/media-requests/index.html
@@ -955,5 +955,4 @@ a.label:focus {
 
     </div>
 
-    {{mediaRequestCtrl.error}}
 </div>

--- a/app/views/kronos/media-requests/index.js
+++ b/app/views/kronos/media-requests/index.js
@@ -207,15 +207,18 @@ export default ['$http', 'kronos', '$q','$scope','$routeParams','$route','$locat
             }).finally(() => { 
 
                     if(!$scope.counts) $scope.counts = {}
-                    for (const request of _ctrl.requests)
-                        if(!request.participants) continue;
-                        else{
-                            for (const participant of request.participants ) 
-                                participant.showPassportForm = false;
-                            request.contactsOnlyError = hasContactsOnlyError(request.participants) 
-                            request.accreditationInProgress = request.accredited? isAccreditationInProgress(request) : false
-                        }
 
+                    if(!_.isEmpty(_ctrl.requests))
+                    {
+                        for (const request of _ctrl.requests)
+                            if(!request.participants) continue;
+                            else{
+                                for (const participant of request.participants ) 
+                                    participant.showPassportForm = false;
+                                request.contactsOnlyError = hasContactsOnlyError(request.participants) 
+                                request.accreditationInProgress = request.accredited? isAccreditationInProgress(request) : false
+                            }
+                    
 
                         if(_ctrl.requestStatus === '' || status === ''){
                             $scope.counts.error                   =  _ctrl.requests.filter(r => r.contactsOnlyError).length;  
@@ -223,26 +226,26 @@ export default ['$http', 'kronos', '$q','$scope','$routeParams','$route','$locat
                             $scope.counts.accredited =  _ctrl.requests.filter(r => !r.contactsOnlyError && !r.accreditationInProgress && r.accredited).length;  
                         }
 
-                    if(_ctrl.requestStatus === 'error' || status === 'error'){
-                        $scope.counts.accreditationInProgress =  _ctrl.requests.filter(r => !r.contactsOnlyError && r.accreditationInProgress  && r.accredited).length;  
-                        $scope.counts.accredited =  _ctrl.requests.filter(r => !r.contactsOnlyError && !r.accreditationInProgress && r.accredited).length; 
-                        _ctrl.requests = _ctrl.requests.filter(r => r.contactsOnlyError );
-                        $scope.counts.error = _ctrl.requests.length
-                    }
-                    if(_ctrl.requestStatus === 'accreditationInProgress' || status === 'accreditationInProgress'){
-                        $scope.counts.error                   =  _ctrl.requests.filter(r => r.contactsOnlyError).length;  
-                        $scope.counts.accredited =  _ctrl.requests.filter(r => !r.contactsOnlyError && !r.accreditationInProgress && r.accredited).length;  
-                        _ctrl.requests = _ctrl.requests.filter(r => !r.contactsOnlyError && r.accreditationInProgress && r.accredited );
-                        $scope.counts.accreditationInProgress = _ctrl.requests.length
-                    }
-                    if(_ctrl.requestStatus === 'accredited' || status === 'accredited'){
-                        $scope.counts.error                   =  _ctrl.requests.filter(r => r.contactsOnlyError).length;  
-                        $scope.counts.accreditationInProgress =  _ctrl.requests.filter(r => !r.contactsOnlyError && r.accreditationInProgress).length;  
+                        if(_ctrl.requestStatus === 'error' || status === 'error'){
+                            $scope.counts.accreditationInProgress =  _ctrl.requests.filter(r => !r.contactsOnlyError && r.accreditationInProgress  && r.accredited).length;  
+                            $scope.counts.accredited =  _ctrl.requests.filter(r => !r.contactsOnlyError && !r.accreditationInProgress && r.accredited).length; 
+                            _ctrl.requests = _ctrl.requests.filter(r => r.contactsOnlyError );
+                            $scope.counts.error = _ctrl.requests.length
+                        }
+                        if(_ctrl.requestStatus === 'accreditationInProgress' || status === 'accreditationInProgress'){
+                            $scope.counts.error                   =  _ctrl.requests.filter(r => r.contactsOnlyError).length;  
+                            $scope.counts.accredited =  _ctrl.requests.filter(r => !r.contactsOnlyError && !r.accreditationInProgress && r.accredited).length;  
+                            _ctrl.requests = _ctrl.requests.filter(r => !r.contactsOnlyError && r.accreditationInProgress && r.accredited );
+                            $scope.counts.accreditationInProgress = _ctrl.requests.length
+                        }
+                        if(_ctrl.requestStatus === 'accredited' || status === 'accredited'){
+                            $scope.counts.error                   =  _ctrl.requests.filter(r => r.contactsOnlyError).length;  
+                            $scope.counts.accreditationInProgress =  _ctrl.requests.filter(r => !r.contactsOnlyError && r.accreditationInProgress).length;  
 
-                        _ctrl.requests = _ctrl.requests.filter(r => !r.accreditationInProgress && !r.contactsOnlyError  && r.accredited); //accredited
-                        $scope.counts.accredited = _ctrl.requests.length
+                            _ctrl.requests = _ctrl.requests.filter(r => !r.accreditationInProgress && !r.contactsOnlyError  && r.accredited); //accredited
+                            $scope.counts.accredited = _ctrl.requests.length
+                        }
                     }
-
                 _ctrl.loading  = false;
 
             })

--- a/app/views/kronos/media-requests/index.js
+++ b/app/views/kronos/media-requests/index.js
@@ -208,7 +208,7 @@ export default ['$http', 'kronos', '$q','$scope','$routeParams','$route','$locat
 
                     if(!$scope.counts) $scope.counts = {}
 
-                    if(!_.isEmpty(_ctrl.requests))
+                    if(!_.isEmpty(_ctrl.requests) && _ctrl.requests.count)
                     {
                         for (const request of _ctrl.requests)
                             if(!request.participants) continue;


### PR DESCRIPTION
Ensures that media request processing, participant data initialization,
and status counting only occur when `_ctrl.requests` is not empty.
This prevents potential JavaScript errors and improves robustness when
no media requests are returned from the API.

The direct display of `mediaRequestCtrl.error` from the UI is also
removed, aligning with the more robust handling of empty data.
