### PR TITLE
Adds early publishing prompt for statements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md — House rules for `scbd/www.cbd.int`
+
+## About this project
+
+**Maintenance project — future migration & decommission.** Do not introduce new features unless they are improvements to an existing one. Keep changes minimal and surgical.
+
+This repo extends the CBD website with small app features focused on meetings and conferences:
+
+- **Meeting page** — meeting listings and detail views
+- **Conference portal** — conference management interface
+- **Meeting-document management** — posting, translation import, and document handling
+- **Decision tracking** — tracking of decisions
+- **BioBridge** — biodiversity bridge initiative
+
+### Stack
+
+Legacy: **AngularJS** and **Vue.js v2**. Both co-exist. If a new feature must be developed, prefer Vue over Angular.
+
+| Path              | Purpose                                           |
+| ----------------- | ------------------------------------------------- |
+| `app/views/`      | Page views — can be Angular or Vue                |
+| `app/routes/`     | Route definitions                                 |
+| `app/components/` | Vue components                                    |
+
+## How we work here
+
+A human decides before code exists. The reasoning gets captured as a byproduct of the design
+conversation — not backfilled afterward. If you (the agent) are about to make a design decision the
+human hasn't seen, **stop and surface it** instead of coding past it.
+
+**Current rollout phase: 0.** The team adopts this workflow in phases (see `ai-era-development/playbook.md`
+in the `scbd/documentation` repo). The rules below are phase-tagged: below their phase, treat them as
+context — never as grounds to refuse or block work. The team bumps this line when it advances a phase.
+
+- *(From Phase 1)* For any non-trivial feature, the human runs `/grill-with-docs` first. Don't start
+  implementation from a vague request — ask for the grilled design.
+- *(From Phase 2)* Every PR must link a Jira slice that **already existed before the branch**. If you
+  can't point to a pre-existing Jira ticket, you are not ready to open a PR. Hotfixes and trivial changes
+  (typos, dependency bumps) are exempt — see the playbook.
+
+## Guardrails (Karpathy) — always on
+
+**1. Think before coding.** State assumptions explicitly. If multiple interpretations exist, present
+them — don't pick silently. If a simpler approach exists, say so. If something's unclear, stop and ask.
+
+**2. Simplicity first.** Minimum code that solves the problem. No features beyond what was asked, no
+speculative abstractions, no "flexibility" nobody requested, no error handling for impossible cases.
+If 200 lines could be 50, rewrite it. Ask: "would a senior engineer call this overcomplicated?"
+
+**3. Surgical changes.** Touch only what the ticket needs. Don't "improve" adjacent code, don't
+refactor things that aren't broken, match existing style. Remove only the orphans *your* change created;
+mention pre-existing dead code, don't delete it. Every changed line should trace to the request.
+
+**4. Goal-driven execution.** Turn the task into a verifiable goal. "Fix the bug" → "write a test that
+reproduces it, then make it pass." For multi-step work, state a short plan with a `verify:` check per step.
+
+Full text: https://github.com/multica-ai/andrej-karpathy-skills/blob/main/skills/karpathy-guidelines/SKILL.md
+
+**AGENT TODO**: Add any repo-specific guardrails beyond these Karpathy defaults (e.g. security,
+secrets/data handling, deploy or migration constraints). Leave as-is if none apply.
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs live in **Jira** (space `DEV`, component `WWW`), read/written through the Atlassian connector. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Two labels in use: `ready-for-agent` (AFK-ready) and `ready-for-human`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+@AGENTS.md
+
+This file exists only to import [`AGENTS.md`](AGENTS.md) into Claude Code's session context
+
+IMPORTANT: update AGENTS.md instead of CLAUDE.md when adding information to agents context.

--- a/app/components/meetings/api.js
+++ b/app/components/meetings/api.js
@@ -165,14 +165,14 @@ export default class Api
     return slot;
   }
 
-  async commitInterventionFileSlot(slotId, passCode, meetingId){
+  async commitInterventionFileSlot(slotId, passCode, meetingId, { earlyPublish } = {}){
     if(!slotId) throw new Error("slotId is empty")
 
     const headers = {
       Authorization : `Pass ${passCode}`
     }
 
-    const data = { meetingId:  meetingId };
+    const data = { meetingId, earlyPublish: !!earlyPublish };
 
     const intervention = await this.http.put(`api/v2021/meeting-interventions/slot/${encodeURIComponent(slotId)}/commit`, data, { headers }).catch(tryCastToApiError);
 

--- a/app/components/meetings/upload-statement-dialog.vue
+++ b/app/components/meetings/upload-statement-dialog.vue
@@ -21,8 +21,12 @@
                         <p v-if="false">TODO Instructions....</p>
 
                         <div v-if="confirmEarlyPublish" class="text-center py-4">
-                            <p class="lead">Allow publishing early statement right away?</p>
+                            <p class="lead">Allow publication of this statement upon upload?</p>
                             <small class="text-muted">(Statement will be publicly visible upon submission)</small>
+                            <div class="mt-3">
+                                <button type="button" class="btn btn-primary mr-2" @click="answerEarlyPublish(true)"><i class="fa fa-check"></i> Yes</button>
+                                <button type="button" class="btn btn-default" @click="answerEarlyPublish(false)"><i class="fa fa-times"></i> No</button>
+                            </div>
                         </div>
 
                         <form v-show="!confirmEarlyPublish" id="statement-submission-form" @submit.prevent="submitForm" enctype="multipart/form-data" ref="form" novalidate :class="{ 'was-validated': wasValidated }">
@@ -165,10 +169,6 @@
                             <button :disabled="!!progress" type="submit" class="btn btn-success" @click="submitForm"><i class="fa fa-upload"></i> <span>Submit</span></button>
                             <button :disabled="!!progress" type="button" class="btn btn-default" @click="close()"><i class="fa fa-power-off"></i> <span class="hidden-xs">Close</span></button>
                         </template>
-                        <template v-else>
-                            <button type="button" class="btn btn-success" @click="answerEarlyPublish(true)"><i class="fa fa-check"></i> Yes</button>
-                            <button type="button" class="btn btn-default" @click="answerEarlyPublish(false)"><i class="fa fa-times"></i> No</button>
-                        </template>
                     </div>
                 </div>
             </div>
@@ -274,7 +274,7 @@ export default {
                 error = { message : "Invalid status: No Meeting or Conference"}
             }
 
-            this.meetings = this.meetings.filter(o=>o.uploadStatement);
+            this.meetings = this.meetings.map(o=>({...o, uploadStatement: true})).filter(o=>o.uploadStatement);
 
             // Only allow agenda items that are configured for statement submission
             // If none are configured, allow all agenda items
@@ -334,7 +334,7 @@ export default {
                 meetingId   : this.selectedAgendaItem.meetingId,
                 filename    : this.file.name,
                 contentType : this.file.type,
-                agendaItem  : ((this.selectedAgendaItem.item || "").toString() || undefined),
+                agendaItem  : Number(this.selectedAgendaItem.item) || undefined,
                 language    : this.selectedLanguage,
                 allowPublic : this.allowPublic===true || this.allowPublic==='true',
                 region      : this.isRegional ? this.selectedRegion : null
@@ -348,7 +348,8 @@ export default {
             const onUploadProgress = (...args) => this.onUploadProgress(...args);
 
             this.progress      = { message: "Uploading...", percent: 0 };
-            this.uploadPromise = this.api.uploadTemporaryFile(this.slot.url, this.file, { contentType, onUploadProgress });
+            this.uploadPromise = this.api.uploadTemporaryFile(this.slot.url, this.file, { contentType, onUploadProgress })
+                                     .then(() => { this.progress = { message: "Upload complete!", percent: 100 }; });
 
             if(this.slot.earlySessionOpen && this.slot.delegationType === 'party') {
                 this.confirmEarlyPublish = true;

--- a/app/components/meetings/upload-statement-dialog.vue
+++ b/app/components/meetings/upload-statement-dialog.vue
@@ -274,7 +274,7 @@ export default {
                 error = { message : "Invalid status: No Meeting or Conference"}
             }
 
-            this.meetings = this.meetings.map(o=>({...o, uploadStatement: true})).filter(o=>o.uploadStatement);
+            this.meetings = this.meetings.filter(o=>o.uploadStatement);
 
             // Only allow agenda items that are configured for statement submission
             // If none are configured, allow all agenda items

--- a/app/components/meetings/upload-statement-dialog.vue
+++ b/app/components/meetings/upload-statement-dialog.vue
@@ -17,10 +17,15 @@
                         </button>
                     </div>
                     <div class="modal-body">
-                        
+
                         <p v-if="false">TODO Instructions....</p>
 
-                        <form  id="statement-submission-form" @submit.prevent="submitForm" enctype="multipart/form-data" ref="form" novalidate :class="{ 'was-validated': wasValidated }">
+                        <div v-if="confirmEarlyPublish" class="text-center py-4">
+                            <p class="lead">Allow publishing early statement right away?</p>
+                            <small class="text-muted">(Statement will be publicly visible upon submission)</small>
+                        </div>
+
+                        <form v-show="!confirmEarlyPublish" id="statement-submission-form" @submit.prevent="submitForm" enctype="multipart/form-data" ref="form" novalidate :class="{ 'was-validated': wasValidated }">
 
                             <div class="form-group row">
                                 <label for="participantIdentity" class="col-sm-3 col-form-label">Priority-Pass or Badge Code</label>
@@ -156,8 +161,14 @@
                             </div>
                         </span>
 
-                        <button :disabled="!!progress" type="submit" class="btn btn-success" @click="submitForm"><i class="fa fa-upload"></i> <span>Submit</span></button>
-                        <button :disabled="!!progress" type="button" class="btn btn-default" @click="close()"><i class="fa fa-power-off"></i> <span class="hidden-xs">Close</span></button>
+                        <template v-if="!confirmEarlyPublish">
+                            <button :disabled="!!progress" type="submit" class="btn btn-success" @click="submitForm"><i class="fa fa-upload"></i> <span>Submit</span></button>
+                            <button :disabled="!!progress" type="button" class="btn btn-default" @click="close()"><i class="fa fa-power-off"></i> <span class="hidden-xs">Close</span></button>
+                        </template>
+                        <template v-else>
+                            <button type="button" class="btn btn-success" @click="answerEarlyPublish(true)"><i class="fa fa-check"></i> Yes</button>
+                            <button type="button" class="btn btn-default" @click="answerEarlyPublish(false)"><i class="fa fa-times"></i> No</button>
+                        </template>
                     </div>
                 </div>
             </div>
@@ -184,19 +195,22 @@ export default {
     },
     data:  function(){
         return {
-            file               : null,
-            meetings           : [],
-            selectedAgendaItem : null,
-            selectedLanguage   : "en",
-            selectedRegion     : null,
-            isRegional         : false,
-            allowPublic        : true,
-            participantIdentity: '',
-            rememberMe         : false,
-            wasValidated       : false,
-            progress           : null,
-            error              : null,
-            grecaptchaToken    : undefined
+            file                : null,
+            meetings            : [],
+            selectedAgendaItem  : null,
+            selectedLanguage    : "en",
+            selectedRegion      : null,
+            isRegional          : false,
+            allowPublic         : true,
+            participantIdentity : '',
+            rememberMe          : false,
+            wasValidated        : false,
+            progress            : null,
+            error               : null,
+            grecaptchaToken     : undefined,
+            confirmEarlyPublish : false,
+            slot                : null,
+            uploadPromise       : null
         }
     },
     created() {
@@ -328,37 +342,74 @@ export default {
 
             this.progress = { message: "Preparing..." };
 
-            const slot    = await this.api.createInterventionFileSlot(passCode, data, this.grecaptchaToken);
+            this.slot = await this.api.createInterventionFileSlot(passCode, data, this.grecaptchaToken);
 
-            this.progress = { message: "Uploading...", percent: 0 };
+            const { contentType } = this.slot;
+            const onUploadProgress = (...args) => this.onUploadProgress(...args);
 
-            const { contentType } = slot;
-            const onUploadProgress = (...args)=> this.onUploadProgress(...args);
+            this.progress      = { message: "Uploading...", percent: 0 };
+            this.uploadPromise = this.api.uploadTemporaryFile(this.slot.url, this.file, { contentType, onUploadProgress });
 
-            await this.api.uploadTemporaryFile(slot.url, this.file, { contentType, onUploadProgress });
+            if(this.slot.earlySessionOpen && this.slot.delegationType === 'party') {
+                this.confirmEarlyPublish = true;
+                return;
+            }
 
+            await this.uploadPromise;
             this.progress = { message: "Saving...", percent: 100 };
 
-            const intervention = await this.api.commitInterventionFileSlot(slot.uid, passCode, data.meetingId);
+            await this.api.commitInterventionFileSlot(this.slot.uid, passCode, data.meetingId, { earlyPublish: !!this.slot.earlySessionOpen });
 
-            this.$emit("notify", `Your file "${slot.metadata.filename}" has been submitted successfully`);
-
+            this.$emit("notify", `Your file "${this.slot.metadata.filename}" has been submitted successfully`);
+            this.progress     = null;
+            this.wasValidated = false;
             this.close();
 
           } catch(err) {
-              if(err.code=='forbidden') this.$refs.participantIdentity.setCustomValidity("Invalid badge or priority-pass number")
-              this.error = err
-              grecaptcha.reset(this.recaptchaWidgetId);
-              this.grecaptchaToken = undefined;
-          } finally {
-            this.progress = null;
+            if(err.code=='forbidden') this.$refs.participantIdentity.setCustomValidity("Invalid badge or priority-pass number")
+            this.error        = err;
+            this.progress     = null;
             this.wasValidated = false;
+            grecaptcha.reset(this.recaptchaWidgetId);
+            this.grecaptchaToken = undefined;
+          }
+        },
+
+        async answerEarlyPublish(answer) {
+          this.confirmEarlyPublish = false;
+          try {
+            await this.uploadPromise;
+            this.progress = { message: "Saving...", percent: 100 };
+
+            await this.api.commitInterventionFileSlot(
+              this.slot.uid,
+              this.cleanParticipantIdentity,
+              this.selectedAgendaItem.meetingId,
+              { earlyPublish: answer }
+            );
+
+            this.$emit("notify", `Your file "${this.slot.metadata.filename}" has been submitted successfully`);
+            this.progress     = null;
+            this.wasValidated = false;
+            this.close();
+
+          } catch(err) {
+            await this.$nextTick();
+            if(err.code=='forbidden') this.$refs.participantIdentity.setCustomValidity("Invalid badge or priority-pass number")
+            this.error        = err;
+            this.progress     = null;
+            this.wasValidated = false;
+            grecaptcha.reset(this.recaptchaWidgetId);
+            this.grecaptchaToken = undefined;
           }
         },
         resetForm(){
             this.wasValidated        = false;
             this.error               = null;
             this.uploading           = false;
+            this.confirmEarlyPublish = false;
+            this.slot                = null;
+            this.uploadPromise       = null;
             this.$refs.file.value    = null;
             this.file                = null;
             this.selectedAgendaItem  = null;
@@ -366,7 +417,7 @@ export default {
             this.selectedRegion      = null;
             this.isRegional          = false;
             this.allowPublic         = true;
-            this.persistIdentity(); 
+            this.persistIdentity();
 
             if(localStorage.participantIdentity) {
                 this.participantIdentity = localStorage.participantIdentity;

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,39 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating
+them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and
+`/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-example-decision.md
+│   └── ...
+└── app/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test
+name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the
+project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (example decision) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,59 @@
+# Issue tracker: Jira
+
+Issues and PRDs for this repo live in **Jira**, read and written through the **Atlassian connector
+(MCP)**. GitHub holds code and PRs only; the two are linked by Jira ticket. This split is intentional:
+non-IT stakeholders track work in Jira, so it is the single source of truth for *what* is being built,
+and a slice ticket must provably predate its branch.
+
+## Coordinates
+
+- **space**: `DEV`      — Jira project key
+- **component**: `WWW`  — Jira component for this repo (always set, even when the space serves only this repo)
+
+## Vocabulary
+
+- **space** — the Jira project key. This repo uses space `DEV`.
+- **component** — the Jira field that identifies the target repo. This repo uses component `WWW`.
+- **epic** — the PRD. One epic = one PRD. Epics are what non-IT stakeholders read and comment on.
+- **issue (slice)** — a vertical slice of an epic, bound to exactly one component. The unit of work an
+  agent or human picks up.
+
+## Conventions
+
+- **Create an epic (PRD):** call `createJiraIssue` with `issueType: Epic` in space `DEV`. The
+  epic description is the PRD.
+- **Create a slice:** call `createJiraIssue` with `issueType: Story` (or `Bug` for defects), linked to
+  its epic via the parent field, and `component: WWW`. Set `labels` to either `ready-for-agent`
+  or `ready-for-human` per the slice mode. Return the Jira ticket (e.g. `DEV-42`) — the eventual PR
+  must link back to this ticket.
+- **Read an issue:** call `getJiraIssue` with the ticket key (e.g. `DEV-42`). The design lives in the
+  description and comments, not in the repo.
+- **Search issues:** call `searchJiraIssuesUsingJql`. Common filters:
+  - All open slices for this repo: `project = DEV AND component = "WWW" AND statusCategory != Done`
+  - AFK-ready slices: `project = DEV AND component = "WWW" AND labels = ready-for-agent`
+- **Comment on an issue:** call `addCommentToJiraIssue`.
+- **Apply / remove labels:** call `editJiraIssue` and set the `labels` field. Jira Labels are the
+  triage vocabulary (see `triage-labels.md`). Labels are set as a complete list — to add one, read the
+  current labels first and include them in the new set.
+- **Transition an issue:** call `getTransitionsForJiraIssue` to get valid transition IDs for the current
+  status, then call `transitionJiraIssue`. Never guess a transition ID.
+- **Close / won't fix:** transition to `Done` with resolution `Won't Do`; add a comment explaining why
+  before transitioning.
+
+The Jira cloud instance and credentials are provided by the Atlassian connector — no manual configuration
+needed.
+
+## PR merge gate
+
+`scbd/pr-reviewers` rejects any PR whose linked Jira slice did not exist before the branch was created,
+and any PR with no linked slice at all. Do not create a slice retroactively to match an existing branch —
+that defeats the rule. Hotfixes and trivial changes (typos, dependency bumps) are exempt.
+
+## When a skill says "publish to the issue tracker"
+
+Create a Jira slice under the relevant epic using `createJiraIssue`. Set `component: WWW` and
+the appropriate label (`ready-for-agent` or `ready-for-human`). Return the ticket to the human.
+
+## When a skill says "fetch the relevant ticket"
+
+Call `getJiraIssue` with the ticket key the human provides (e.g. `DEV-42`).

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,12 @@
+# Triage Labels
+
+The skills speak in terms of canonical triage roles. This file maps those roles to the actual label strings used in this repo's Jira project (`DEV`, component `WWW`).
+
+| Label in mattpocock/skills | Label in our tracker  | Meaning                                 |
+| -------------------------- | --------------------- | --------------------------------------- |
+| `ready-for-agent`          | `ready-for-agent`     | Fully specified, ready for an AFK agent |
+| `ready-for-human`          | `ready-for-human`     | Requires human implementation           |
+
+Only these two labels are used. `needs-triage`, `needs-info`, and `wontfix` are not part of this project's Jira workflow.
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.


### PR DESCRIPTION
Introduces a confirmation prompt for early publication of statements. This prompt appears when a party delegation submits a statement during an early session, asking if the statement should be made public immediately upon submission.

- Updates the statement submission API to accept an `earlyPublish` flag, controlling the immediate visibility of the submitted document.
- Refines the filtering logic for available meetings and the parsing of agenda item numbers.

Also establishes comprehensive guidelines for AI agents working with this repository:
- Includes detailed documentation on project scope, technology stack, workflow phases, and best practices (Karpathy's guardrails).
- Defines how agents should interact with Jira for issue tracking (DEV space, WWW component) and use specific triage labels (`ready-for-agent`, `ready-for-human`).
- Outlines conventions for consuming domain documentation, including `CONTEXT.md` and `docs/adr/`.

Relates to DEV-1024