### PR TITLE
(fix) Make vue-i18n global via Vue.mixin so ngVue roots get $t

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -106,7 +106,10 @@ const app = angular.module('app', angular.defineModules(
       locale        : locale,
       fallbackLocale: 'en',
     })
-    window.Vue.use(i18n)
+
+    // Inject the shared i18n into every Vue instance (including each ngVue root),
+    // so components can use $t without vueOptions passing an i18n instance.
+    window.Vue.mixin({ i18n })
 
     const vueRootApp = new Vue({i18n});
 

--- a/app/views/vue-view-wrapper.js
+++ b/app/views/vue-view-wrapper.js
@@ -1,17 +1,15 @@
 import 'angular-vue'
-import VueI18n from 'vue-i18n'
 
 export { default as template } from './vue-view-wrapper.html';
 
-export default ['$scope', 'apiToken', '$route', 'component', 'locale',
- function ($scope, apiToken, $route, component, locale) {
+export default ['$scope', 'apiToken', '$route', 'component',
+ function ($scope, apiToken, $route, component) {
 
   component = component.default || component;
 
   $scope.tokenReader = function(){ return apiToken.get()}
   $scope.route       = { params : $route.current.params }
   $scope.vueOptions  = {
-    components: { component },
-    // i18n: new VueI18n({ locale: locale, fallbackLocale: 'en', messages: { en: {} } })
+    components: { component }
   };
 }];


### PR DESCRIPTION
Each ngVue-mounted component is its own Vue root and did not inherit the
app-level i18n, causing "Cannot read properties of undefined (reading '_t')".
Inject the shared i18n through a global mixin and drop the per-view instance
from the vue-view-wrapper.
