### PR TITLE
feat(DEV-1040): collapse superseded statements in early-submission sessions

### DIFF
--- a/app/components/meetings/api.js
+++ b/app/components/meetings/api.js
@@ -367,6 +367,52 @@ function getAllSessions(interventions){
   return Array.from(new Set(interventions.map(({ sessionId }) => sessionId)))
 }
 
+// UI-derived superseded lineage (no backend flag). Groups a party's submissions for the same
+// agenda item and folds older versions into the newest one, returning a top-level list where each
+// current statement carries its previous versions as collapsed `supersededChildren`.
+export function markSupersededInterventions(interventions) {
+  // partyKey = government || organizationId, else fall back to _id (singleton guard so legacy rows
+  // missing both fields never wrongly group together).
+  const partyKeyOf = i => i.government || i.organizationId || i._id
+  const keyOf      = i => [i.meetingId, i.sessionId, i.agendaItem, partyKeyOf(i)].join('|')
+
+  const groups = new Map()
+  for (const i of interventions) {
+    const key = keyOf(i)
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key).push(i)
+  }
+
+  // newest (by datetime) member per group = the current statement
+  const newestIdByKey = new Map()
+  for (const [key, group] of groups) {
+    const newest = group.reduce((a, b) => new Date(a.datetime) >= new Date(b.datetime) ? a : b)
+    newestIdByKey.set(key, newest._id)
+  }
+
+  // Emit a top-level list in the original (datetime-sorted) order. Older versions are folded into
+  // their newest sibling and travel as reverse-chronological children.
+  const result = []
+  for (const i of interventions) {
+    const key   = keyOf(i)
+    const group = groups.get(key)
+
+    if (group.length < 2) { result.push(i); continue }   // singleton — unchanged
+    if (newestIdByKey.get(key) !== i._id) continue        // older version — folded into its parent
+
+    const children = group
+      .filter(o => o._id !== i._id)
+      .sort((a, b) => new Date(b.datetime) - new Date(a.datetime)) // newest superseded first
+
+    result.push({
+      ...i,
+      expanded          : false,          // reactive collapse state for the public view
+      supersededChildren: children,
+    })
+  }
+  return result
+}
+
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //             TO REVIEW

--- a/app/components/meetings/api.js
+++ b/app/components/meetings/api.js
@@ -385,8 +385,9 @@ export function markSupersededInterventions(interventions) {
 
   // newest (by datetime) member per group = the current statement
   const newestIdByKey = new Map()
+  const ts = i => { const t = new Date(i.datetime).getTime(); return Number.isNaN(t) ? -Infinity : t }
   for (const [key, group] of groups) {
-    const newest = group.reduce((a, b) => new Date(a.datetime) >= new Date(b.datetime) ? a : b)
+    const newest = group.reduce((a, b) => ts(a) >= ts(b) ? a : b)
     newestIdByKey.set(key, newest._id)
   }
 
@@ -402,7 +403,7 @@ export function markSupersededInterventions(interventions) {
 
     const children = group
       .filter(o => o._id !== i._id)
-      .sort((a, b) => new Date(b.datetime) - new Date(a.datetime)) // newest superseded first
+      .sort((a, b) => ts(b) - ts(a)) // newest superseded first
 
     result.push({
       ...i,

--- a/app/components/meetings/locales.js
+++ b/app/components/meetings/locales.js
@@ -3,7 +3,11 @@ export default { messages: {
     hello:'world',
     CBD: 'CBD',
     NP: 'NP',
-    CP: 'CP'
+    CP: 'CP',
+    'previous versions': 'previous versions',
+    'Show previous versions': 'Show previous versions',
+    'Hide previous versions': 'Hide previous versions',
+    'Pending': 'Pending'
   }
 }
 }

--- a/app/components/meetings/sessions/intervention-row.vue
+++ b/app/components/meetings/sessions/intervention-row.vue
@@ -1,5 +1,5 @@
 <template >
-  <tr :_id="intervention._id" :class="{ 'intervention-child': isChild }" @click="$parent.$emit('select')">
+  <tr :_id="intervention._id" :class="{ 'intervention-child': isChild, 'text-muted': isChild }" @click="$parent.$emit('select')">
 
     <td scope="row" class="index-col d-none d-lg-table-cell" style="text-align: center; vertical-align: middle;">
         <small v-if="isChild" class="text-muted lighter">{{ subIndex }}</small>
@@ -24,12 +24,13 @@
     <td style="vertical-align: middle;"> 
         <span class="float-right text-muted">{{ getOrgType(intervention) }} </span>
 
-        <a v-if="hasSuperseded" href="#" class="superseded-toggle float-right"
+        <button type="button" v-if="hasSuperseded" class="superseded-toggle float-right text-muted"
+          role="button" :aria-expanded="intervention.expanded ? 'true' : 'false'"
           :title="intervention.expanded ? $t('Hide previous versions') : $t('Show previous versions')"
           @click.prevent.stop="$emit('toggle')">
           <i class="fa" :class="intervention.expanded ? 'fa-caret-down' : 'fa-caret-right'"></i>
           {{ $t('previous versions') }}
-        </a>
+        </button>
 
         <span class="title">{{ intervention.title }}</span>
         <div v-if="intervention.summary" class="text-muted small summary">{{intervention.summary}}</div>
@@ -172,9 +173,6 @@ table.sessions {
 }
 
 /* Collapsed superseded versions, shown dimmed under their current statement */
-tr.intervention-child {
-  color: #6c757d;
-}
 tr.intervention-child .title {
   font-weight: normal;
 }
@@ -185,8 +183,10 @@ tr.intervention-child .files-col a[target="_blank"] {
 .superseded-toggle {
   margin-right: 0.75rem;
   font-size: 0.85em;
-  color: #6c757d;
   white-space: nowrap;
+  background: none;
+  border: none;
+  padding: 0;
 }
 .superseded-toggle .fa {
   margin-right: 0.25rem;

--- a/app/components/meetings/sessions/intervention-row.vue
+++ b/app/components/meetings/sessions/intervention-row.vue
@@ -173,7 +173,7 @@ table.sessions {
 
 /* Collapsed superseded versions, shown dimmed under their current statement */
 tr.intervention-child {
-  color: #999;
+  color: #6c757d;
 }
 tr.intervention-child .title {
   font-weight: normal;

--- a/app/components/meetings/sessions/intervention-row.vue
+++ b/app/components/meetings/sessions/intervention-row.vue
@@ -178,6 +178,9 @@ tr.intervention-child {
 tr.intervention-child .title {
   font-weight: normal;
 }
+tr.intervention-child .files-col {
+  text-decoration: line-through;
+}
 
 .superseded-toggle {
   margin-right: 0.75rem;

--- a/app/components/meetings/sessions/intervention-row.vue
+++ b/app/components/meetings/sessions/intervention-row.vue
@@ -178,7 +178,7 @@ tr.intervention-child {
 tr.intervention-child .title {
   font-weight: normal;
 }
-tr.intervention-child .files-col {
+tr.intervention-child .files-col a[target="_blank"] {
   text-decoration: line-through;
 }
 

--- a/app/components/meetings/sessions/intervention-row.vue
+++ b/app/components/meetings/sessions/intervention-row.vue
@@ -1,8 +1,9 @@
 <template >
-  <tr :_id="intervention._id" @click="$parent.$emit('select')">
+  <tr :_id="intervention._id" :class="{ 'intervention-child': isChild }" @click="$parent.$emit('select')">
 
     <td scope="row" class="index-col d-none d-lg-table-cell" style="text-align: center; vertical-align: middle;">
-        <b  v-if="!isPending(intervention.status)">{{index}}.</b>
+        <small v-if="isChild" class="text-muted lighter">{{ subIndex }}</small>
+        <b  v-else-if="!isPending(intervention.status)">{{index}}.</b>
         <small v-if="isPending(intervention.status)" class="text-muted lighter">{{$t('Pending')}}</small>
     </td>
 
@@ -21,7 +22,14 @@
     </td>
 
     <td style="vertical-align: middle;"> 
-        <span class="float-right text-muted">{{ getOrgType(intervention) }} </span>  
+        <span class="float-right text-muted">{{ getOrgType(intervention) }} </span>
+
+        <a v-if="hasSuperseded" href="#" class="superseded-toggle float-right"
+          :title="intervention.expanded ? $t('Hide previous versions') : $t('Show previous versions')"
+          @click.prevent.stop="$emit('toggle')">
+          <i class="fa" :class="intervention.expanded ? 'fa-caret-down' : 'fa-caret-right'"></i>
+          {{ $t('previous versions') }}
+        </a>
 
         <span class="title">{{ intervention.title }}</span>
         <div v-if="intervention.summary" class="text-muted small summary">{{intervention.summary}}</div>
@@ -72,6 +80,8 @@ export default {
   components: { AgendaItem, FilesView, FilesPreview },
   props     : { 
                   index       : { type: Number,  required: false, default:null },
+                  subIndex    : { type: String,  required: false, default: null },
+                  isChild     : { type: Boolean, required: false, default: false },
                   intervention: { type: Object,  required: true },
                   showDate    : { type: Boolean, required: false, default: true },
                   showTime    : { type: Boolean, required: false, default: true },
@@ -81,7 +91,7 @@ export default {
               },
   methods   : { getOrgType, isPending },
   filters   : { formatDate, setTimezone },
-  computed  : { tags },
+  computed  : { tags, hasSuperseded },
   i18n, 
 }
 
@@ -93,6 +103,10 @@ function tags() {
     tags = tags.filter(isTagPublic);
 
   return tags.map(tag=>({ tag, title: getTagTitle(tag) }));
+}
+
+function hasSuperseded() {
+  return !!(this.intervention.supersededChildren && this.intervention.supersededChildren.length)
 }
 
 function getOrgType({ organizationType }){
@@ -155,6 +169,24 @@ table.sessions {
 
 .title {
   font-weight: bold;
+}
+
+/* Collapsed superseded versions, shown dimmed under their current statement */
+tr.intervention-child {
+  color: #999;
+}
+tr.intervention-child .title {
+  font-weight: normal;
+}
+
+.superseded-toggle {
+  margin-right: 0.75rem;
+  font-size: 0.85em;
+  color: #6c757d;
+  white-space: nowrap;
+}
+.superseded-toggle .fa {
+  margin-right: 0.25rem;
 }
 
 .summary { 

--- a/app/components/meetings/sessions/view.vue
+++ b/app/components/meetings/sessions/view.vue
@@ -146,7 +146,12 @@ async function loadInterventions(sessionId){
       s = { agendaItem: 1, title:1 };
     }
 
-    session.interventions = markSupersededInterventions(await this.api.queryInterventions({ q, s }));
+    const interventions = await this.api.queryInterventions({ q, s });
+
+    // Superseded lineage only applies to early-submission sessions.
+    session.interventions = session.earlySubmission
+      ? markSupersededInterventions(interventions)
+      : interventions;
 }
 
 function numberOfSessions(){

--- a/app/components/meetings/sessions/view.vue
+++ b/app/components/meetings/sessions/view.vue
@@ -37,13 +37,27 @@
         </div>
       </template>
 
-      <InterventionRow v-for="(intervention, index) in interventions" v-bind="{intervention}" :timezone="timezone" :index="index+1" v-bind:key="intervention._id" :public-view="true">
-        <template v-slot:controls>
-          <div class="video">
-            <VideoLink :videos="videos" :start-at="intervention.datetime" :title="`Start at intervention of ${intervention.title}`"/>
-          </div>
-        </template>
-      </InterventionRow>
+      <template v-for="(intervention, index) in interventions">
+
+        <InterventionRow v-bind="{intervention}" :timezone="timezone" :index="index+1" :key="intervention._id" :public-view="true"
+          @toggle="intervention.expanded = !intervention.expanded">
+          <template v-slot:controls>
+            <div class="video">
+              <VideoLink :videos="videos" :start-at="intervention.datetime" :title="`Start at intervention of ${intervention.title}`"/>
+            </div>
+          </template>
+        </InterventionRow>
+
+        <InterventionRow v-for="(child, ci) in (intervention.expanded ? intervention.supersededChildren : [])"
+          :intervention="child" :timezone="timezone" :sub-index="`${index+1}.${ci+1}`" :is-child="true" :key="child._id" :public-view="true">
+          <template v-slot:controls>
+            <div class="video">
+              <VideoLink :videos="videos" :start-at="child.datetime" :title="`Start at intervention of ${child.title}`"/>
+            </div>
+          </template>
+        </InterventionRow>
+
+      </template>
 
     </Session>
 
@@ -51,7 +65,7 @@
 </template>
 
 <script>
-import   Api, { mapObjectId } from '../api.js'
+import   Api, { mapObjectId, markSupersededInterventions } from '../api.js'
 import   Session           from './session.vue'
 import   InterventionRow   from './intervention-row.vue'
 import   VideoLink         from './video-link.vue'
@@ -132,7 +146,7 @@ async function loadInterventions(sessionId){
       s = { agendaItem: 1, title:1 };
     }
 
-    session.interventions = await this.api.queryInterventions({ q, s });
+    session.interventions = markSupersededInterventions(await this.api.queryInterventions({ q, s }));
 }
 
 function numberOfSessions(){


### PR DESCRIPTION
## Details
In the public meeting-session view, an early-submission session's repeat statements from the same
party for the same agenda item now collapse under that party's latest submission instead of
rendering as equal sibling rows.

- The current statement shows as a single row with a caret toggle (with a "Show/Hide previous
  versions" tooltip and visible "previous versions" label).
- Expanding reveals the previous versions, dimmed, in reverse-chronological order, numbered
  `N.1`, `N.2`, ..., with the file link struck through.
- UI-derived only (no backend change). Grouping key is `meetingId + sessionId + agendaItem + partyKey`,
  where `partyKey = government || organizationId || _id` (the `_id` fallback is a singleton guard so
  legacy rows missing both party fields never group).
- Gated to sessions flagged `earlySubmission === true`; every other session (and the staff "pending"
  view) renders the flat list exactly as before.

Key files: `app/components/meetings/api.js` (`markSupersededInterventions`),
`app/components/meetings/sessions/view.vue` (gating + nested render),
`app/components/meetings/sessions/intervention-row.vue` (toggle, sub-numbering, dimming, strikethrough).

## Testing
- `npm run build` passes (rollup + Vue SFC compile clean; only pre-existing warnings).
- Unit-tested the grouping logic against an SBSTTA-style scenario: a single submission stays a
  top-level row; the newest submission becomes the parent with reverse-chronological children
  (`N.1` newest superseded, `N.2` oldest); a legacy row missing both `government` and
  `organizationId` stays an independent singleton.
- Backward compatibility: the staff edit / interpreter / session views pass a numeric `index` and
  never set the new props, so they render unchanged.

## User-Facing Changes
On early-submission sessions, a party's superseded statements are now tucked under their latest one
and revealed on demand (caret toggle), rather than cluttering the list as equal rows. Older versions
appear dimmed, reverse-chronologically numbered, with their file link struck through.

_No screenshots captured in this session._

## Summary
Closes [DEV-1040](https://scbd.atlassian.net/browse/DEV-1040) from epic [DEV-1008](https://scbd.atlassian.net/browse/DEV-1008)


[DEV-1040]: https://scbd.atlassian.net/browse/DEV-1040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="1586" height="1071" alt="image" src="https://github.com/user-attachments/assets/7f01eb81-921d-4bf0-b48f-d468cbc0339b" />
