### PR TITLE
fix(UI): Consolidate original and AI files into a single display column

### DIFF
--- a/app/components/meetings/sessions/files-view.vue
+++ b/app/components/meetings/sessions/files-view.vue
@@ -125,7 +125,7 @@ function onFileClick(file, event) {
   color: #fff !important;
 }
 
-.file-icon .fa-language {
+.file-icon {
   margin-right: 0.15em;
 }
 

--- a/app/components/meetings/sessions/intervention-row.vue
+++ b/app/components/meetings/sessions/intervention-row.vue
@@ -58,11 +58,10 @@
 
     <td class="files-col" style="text-align: center; vertical-align: middle;">
         <FilesView :files="nonAiFiles" :show-preview-as-button="showPreviewAsButton"/>
+        <FilesView v-if="showAiColumn" :files="aiFiles" :allow-preview-text="false"/>
     </td>
 
-    <td class="files-col" style="text-align: center; vertical-align: middle;" v-if="showAiColumn">
-        <FilesView :files="aiFiles" :allow-preview-text="false"/>
-    </td>
+  
 
     <td class="controls-col" >
         <slot name="controls"/>


### PR DESCRIPTION
The display of intervention files now merges original and AI-translated files into a single table column in `intervention-row.vue`. This simplifies the table layout by removing the previously separate column dedicated to AI translations.

Additionally, a minor CSS adjustment in `files-view.vue` broadens a margin rule to the parent `.file-icon` class, ensuring consistent spacing for various icons within the unified file display.
