### PR TITLE
feat(UI): Add language icon to AI disclaimer banner

### DIFF
--- a/app/components/meetings/sessions/view.vue
+++ b/app/components/meetings/sessions/view.vue
@@ -1,6 +1,9 @@
 <template >
   <div>
-    <div v-if="hasAiTranslations" class="alert alert-warning" role="alert">{{ $t('aiDisclaimerText') }}</div>
+    <div v-if="hasAiTranslations" class="alert alert-warning" role="alert">
+      <i class="fa fa-language"></i>
+      {{ $t('aiDisclaimerText') }}
+    </div>
 
     <Session :_id="_id" class="card"
       :body-class="{'collapse':true, 'show': numberOfSessions==1 }" 


### PR DESCRIPTION
Places a `fa-language` icon in the session-level warning banner that appears when AI translations are present, improving visual identification of the disclaimer text.
