### PR TITLE
DEV-1082 Fixes passport read API URL path

### DIFF
--- a/app/directives/kronos/passport.js
+++ b/app/directives/kronos/passport.js
@@ -80,7 +80,7 @@ app.directive('passport', ['$http','$filter','translationService','locale','kron
               if(type.startsWith('image')) $scope.binding.imageSrc = $scope.image;
 
 
-              const { imageSrc, fields, valid } = (await $http.post(`${kronos.kronosCbdEventsUrl}/passports/api/read`, body, { headers })).data;
+              const { imageSrc, fields, valid } = (await $http.post(`${kronos.kronosCbdEventsUrl}/api/passports/read`, body, { headers })).data;
 
               if(!valid) $scope.triggerForm();
 


### PR DESCRIPTION
Corrects the API endpoint for reading passport data.

The previous URL path for the passport read operation was malformed, causing requests to fail. This change updates the endpoint to the correct structure, ensuring successful communication with the backend service.

Fixes DEV-1082