### PR TITLE
feat(UI): Auto-refresh open sessions in the public statements view

### DIFF
--- a/app/components/meetings/sessions/intervention-row.vue
+++ b/app/components/meetings/sessions/intervention-row.vue
@@ -101,11 +101,11 @@ export default {
 }
 
 function nonAiFiles() {
-  return this.intervention.files.filter(f => !f.autoTranslated);
+  return this.intervention?.files?.filter(f => !f.autoTranslated);
 }
 
 function aiFiles() {
-  return this.intervention.files.filter(f => f.autoTranslated);
+  return this.intervention?.files?.filter(f => f.autoTranslated);
 }
 
 function tags() {
@@ -119,7 +119,7 @@ function tags() {
 }
 
 function hasSuperseded() {
-  return !!(this.intervention.supersededChildren && this.intervention.supersededChildren.length)
+  return !!(this.intervention?.supersededChildren && this.intervention.supersededChildren.length)
 }
 
 function getOrgType({ organizationType }){

--- a/app/components/meetings/sessions/intervention-row.vue
+++ b/app/components/meetings/sessions/intervention-row.vue
@@ -119,7 +119,7 @@ function tags() {
 }
 
 function hasSuperseded() {
-  return !!(this.intervention?.supersededChildren && this.intervention.supersededChildren.length)
+  return !!(this.intervention?.supersededChildren?.length)
 }
 
 function getOrgType({ organizationType }){

--- a/app/components/meetings/sessions/session.vue
+++ b/app/components/meetings/sessions/session.vue
@@ -4,6 +4,8 @@
     <slot name="header"/>
 
     <div :class="bodyClass" :id="bodyId" >
+      <slot name="body-header"/>
+
       <table class="table table-striped table-hover no-border-first-row sessions">
         <tbody>
           <slot>

--- a/app/components/meetings/sessions/view.vue
+++ b/app/components/meetings/sessions/view.vue
@@ -7,9 +7,9 @@
 
       <template v-slot:header>
 
-        <div class="card-header" data-toggle="collapse" :data-target="`#sid${_id}`" :class="{ collapsed: numberOfSessions>1 }" >
-          <h5 @click="!interventions && loadInterventions(_id)"
-           :title="date | setTimezone(timezone) | format('z')"> 
+        <div class="card-header" data-toggle="collapse" :data-target="`#sid${_id}`" :class="{ collapsed: numberOfSessions>1 }"
+          @click="!interventions && loadInterventions(_id)">
+          <h5 :title="date | setTimezone(timezone) | format('z')">
             {{ title }}
             <span v-if="!title" >
               {{ date | setTimezone(timezone) | format('cccc, d MMMM yyyy - T') }}
@@ -197,7 +197,7 @@ async function loadInterventions(sessionId){
     session.refreshing = true;
 
     try {
-      const interventions = await this.api.queryInterventions({ q, s });
+      const interventions = await this.api.queryInterventions({ q, s }) || [];
 
       // Superseded lineage only applies to early-submission sessions.
       session.interventions = session.earlySubmission
@@ -206,6 +206,10 @@ async function loadInterventions(sessionId){
 
       session.hasAiTranslations = hasAiTranslations(session.interventions);
       session.lastUpdated       = new Date();
+    }
+    catch(e) {
+      console.error(e);
+      session.interventions = session.interventions || []; // never leave the header spinning
     }
     finally { session.refreshing = false }
 }
@@ -220,7 +224,7 @@ function isStaff(){
 }
 
 function hasTranslatedFile(intervention) {
-  return intervention.files.some(f => f.autoTranslated);
+  return intervention.files?.some(f => f.autoTranslated);
 }
 
 function hasAiTranslations(interventions) {

--- a/app/components/meetings/sessions/view.vue
+++ b/app/components/meetings/sessions/view.vue
@@ -1,14 +1,9 @@
 <template >
   <div>
-    <div v-if="hasAiTranslations" class="alert alert-warning" role="alert">
-      <i class="fa fa-language"></i>
-      {{ $t('aiDisclaimerText') }}
-    </div>
-
     <Session :_id="_id" class="card"
-      :body-class="{'collapse':true, 'show': numberOfSessions==1 }" 
-      :body-id="`sid${_id}`" 
-      v-for="{ title, _id, interventions, date, videos, count, timezone, earlySubmission, cutoffDate } in sessions" :key="_id">
+      :body-class="{'collapse':true, 'show': numberOfSessions==1 }"
+      :body-id="`sid${_id}`"
+      v-for="{ title, _id, interventions, date, videos, count, timezone, earlySubmission, cutoffDate, lastUpdated, refreshing, hasAiTranslations } in sessions" :key="_id">
 
       <template v-slot:header>
 
@@ -32,6 +27,12 @@
               <VideoLink class="pull-right" :videos="videos" title="Full session webcast"/>
             </span>
 
+            <small v-if="isStaff && lastUpdated" class="text-muted tiny last-update" title="Auto-refreshed every minute">
+              <i class="fa fa-refresh" :class="{ 'fa-spin': refreshing }" title="Refresh now"
+                 @click.stop="!refreshing && loadInterventions(_id)"></i>
+              last update {{ lastUpdated | format('T') }}
+            </small>
+
             <br> 
             
             <small class="text-muted">
@@ -46,6 +47,13 @@
             
           </h5>
 
+        </div>
+      </template>
+
+      <template v-slot:body-header>
+        <div v-if="hasAiTranslations" class="alert alert-warning" role="alert">
+          <i class="fa fa-language"></i>
+          {{ $t('aiDisclaimerText') }}
         </div>
       </template>
 
@@ -85,6 +93,8 @@ import   i18n              from '../locales.js'
 import { format, timezone as setTimezone } from '../datetime.js'
 import remapCode from './re-map.js'
 
+const STAFF_ROLES = [ 'ScbdStaff', 'EditorialService' ]; // same definition of "staff" as documents.js
+
 export default {
   name       : 'SessionsView',
   components : { Session, InterventionRow, VideoLink },
@@ -92,16 +102,17 @@ export default {
                   route:       { type: Object, required: false },
                   tokenReader: { type: Function, required: false }
                 },
-  computed   : { numberOfSessions, hasAiTranslations },
+  computed   : { numberOfSessions, isStaff },
   filters    : { format, setTimezone },
-  methods    : { loadInterventions },
-  created, data,
+  methods    : { loadInterventions, refreshOpenSessions },
+  created, mounted, beforeDestroy, data,
   i18n,
 }
 
 function data(){
   return { 
     sessions: [],
+    refreshTimer: null,
   }
 }
 
@@ -119,7 +130,10 @@ async function created(){
     return {
       ...session,
       videos,
-      interventions : null, //Make it reactive
+      interventions     : null, //Make it reactive
+      lastUpdated       : null, //Make it reactive
+      refreshing        : false,//Make it reactive
+      hasAiTranslations : false,//Make it reactive
     }
   });
 
@@ -141,9 +155,29 @@ async function created(){
       title: `${meeting.EVT_CD} - Pending statements`,
       count: pendingSession.count,
       meetingId: meeting._id,
-      interventions : null,
-    });  
+      interventions     : null,
+      lastUpdated       : null,
+      refreshing        : false,
+      hasAiTranslations : false,
+    });
   }
+}
+
+function mounted(){
+  this.refreshTimer = setInterval(this.refreshOpenSessions, 60 * 1000)
+}
+
+function beforeDestroy(){
+  if(this.refreshTimer) clearInterval(this.refreshTimer)
+}
+
+// Staff follow live sessions; reload the ones the reader currently has expanded.
+async function refreshOpenSessions(){
+  if(!this.isStaff) return;
+
+  const isExpanded = ({ _id }) => document.getElementById(`sid${_id}`)?.classList.contains('show');
+
+  await Promise.all(this.sessions.filter(isExpanded).map(s => this.loadInterventions(s._id)));
 }
 
 async function loadInterventions(sessionId){
@@ -160,27 +194,39 @@ async function loadInterventions(sessionId){
       s = { agendaItem: 1, title:1 };
     }
 
-    const interventions = await this.api.queryInterventions({ q, s });
+    session.refreshing = true;
 
-    // Superseded lineage only applies to early-submission sessions.
-    session.interventions = session.earlySubmission
-      ? markSupersededInterventions(interventions)
-      : interventions;
+    try {
+      const interventions = await this.api.queryInterventions({ q, s });
+
+      // Superseded lineage only applies to early-submission sessions.
+      session.interventions = session.earlySubmission
+        ? markSupersededInterventions(interventions)
+        : interventions;
+
+      session.hasAiTranslations = hasAiTranslations(session.interventions);
+      session.lastUpdated       = new Date();
+    }
+    finally { session.refreshing = false }
 }
 
 function numberOfSessions(){
   return this.sessions?.length || 0
 }
 
+// The Angular route resolves the user before this component is created.
+function isStaff(){
+  return !!this.$auth?.hasScope(STAFF_ROLES)
+}
+
 function hasTranslatedFile(intervention) {
   return intervention.files.some(f => f.autoTranslated);
 }
 
-function hasAiTranslations() {
-  return (this.sessions || []).some(s =>
-    (s.interventions || []).some(i =>
-      hasTranslatedFile(i) ||
-      (i.supersededChildren || []).some(hasTranslatedFile)))
+function hasAiTranslations(interventions) {
+  return (interventions || []).some(i =>
+    hasTranslatedFile(i) ||
+    (i.supersededChildren || []).some(hasTranslatedFile))
 }
 </script>
 
@@ -190,10 +236,15 @@ function hasAiTranslations() {
   .card-header .video { float: right; color: #404040; }
   .card-header .video { margin-right: -7px; }
 
+  .card-header .last-update { float: right; margin-left: 10px; }
+  .card-header .last-update .fa-refresh { cursor: pointer; }
+
   h5 { color: #009b48;}
 
   .card        { border: none; }
-  .card-header { cursor: default; }
+
+  /* Sticks while its own session is on screen, then the next header pushes it out. */
+  .card-header { cursor: default; position: sticky; top: 0; z-index: 2; background-color: #f7f7f7; }
 
   .card-header           .fa-caret-up   { display: none; }
   .card-header.collapsed .fa-caret-up   { display: inline; }

--- a/app/components/meetings/sessions/view.vue
+++ b/app/components/meetings/sessions/view.vue
@@ -23,7 +23,7 @@
             <i v-if="!interventions" class="loading text-muted  fa fa-cog fa-spin"></i>
             
 
-            <span class="video" v-if="videos && videos.length">
+            <span class="video" v-if="videos && videos.length" @click.stop>
               <VideoLink class="pull-right" :videos="videos" title="Full session webcast"/>
             </span>
 


### PR DESCRIPTION
Follow-up to #726, on the public meeting **Statements** tab.

### Auto-refresh (staff only)
- Every 60s, reloads the sessions the reader currently has expanded. Cleared in `beforeDestroy`.
- Gated on `ScbdStaff`/`EditorialService` via `$auth.hasScope` - non-staff never poll.
- Session headers now show `last update HH:MM` on the right, with a refresh icon that spins while loading and reloads that session on click.
- Session headers are sticky at `top: 0` until the next one pushes them out.

### AI disclaimer is now per session
Moved from a single banner above the whole list into each session's body (new `body-header` slot on `session.vue`), and `hasAiTranslations` is computed per session instead of across all of them. The AI file column follows the same per-session flag.

### Fix: session stuck on the loading spinner
Interventions created with the *fileless intervention* button have no `files` array, so `hasTranslatedFile` threw during render. Vue 2 falls back to the previous vnode on a render error, so the rows never appeared and the header spinner stayed on screen - and since the check scanned every session, one such record froze the whole view. Before #721 this was absorbed by `FilesView`'s `default: () => []` prop.

Also in that fix: `loadInterventions` now catches failures so a timeout/500 stops the spinner, and the load trigger moved from the `h5` to the `.card-header` that owns the collapse - previously a click on the header's padding expanded the section without loading it.

**Testing**: `npx rollup -c` builds clean. Browser passes still needed - notably: create a fileless intervention on session prep, then expand that session here (reproduced the hang before this change); confirm polling only happens for staff and stops after navigating away.