### PR TITLE
Translation request visibility + filename language detection

### DIFF
--- a/app/boot.js
+++ b/app/boot.js
@@ -128,6 +128,14 @@ export default function bootApp(window, require, defineX) {
       return xlsx;
   });
 
+  // ESM-only libraries cannot go through requirejs `paths`, which loads a classic script: hand the
+  // URL to the browser's own module loader. Built from a string so the bundler leaves the native
+  // import alone instead of rewriting it into an AMD require.
+  const importEsm = new Function('url', 'return import(url)');
+
+  // A loader, not franc itself: nothing is fetched until the first detection.
+  defineX('franc', [], () => () => importEsm(`${cdnUrl}npm/franc-min@6.2.0/+esm`).then(m => m.franc));
+
   defineX('dropbox-dropins', ['https://www.dropbox.com/static/api/2/dropins.js'], function(){
       if(window.Dropbox)
           window.Dropbox.appKey = "uvo7kuhmckw68pl"; //registration@cbd.int

--- a/app/components/meetings/api.js
+++ b/app/components/meetings/api.js
@@ -208,9 +208,9 @@ export default class Api
     return file;
   }   
 
-  async requestInterventionFileTranslation(interventionId, fileId, targetLanguage){
+  async requestInterventionFileTranslation(interventionId, fileId, targetLanguage, isPublic){
 
-    const status = await this.http.post(`api/v2021/meeting-interventions/${encodeURIComponent(interventionId)}/files/${encodeURIComponent(fileId)}/translations`, { targetLanguage }).then(res => res.data).catch(tryCastToApiError);
+    const status = await this.http.post(`api/v2021/meeting-interventions/${encodeURIComponent(interventionId)}/files/${encodeURIComponent(fileId)}/translations`, { targetLanguage, public: isPublic }).then(res => res.data).catch(tryCastToApiError);
 
     return status;
   }

--- a/app/components/meetings/sessions/edit-intervention-modal.vue
+++ b/app/components/meetings/sessions/edit-intervention-modal.vue
@@ -109,7 +109,7 @@
                             <h5>Files</h5>
                             <hr>
 
-                            <div v-for="row in fileRows" :key="row.key" class="form-group row">
+                            <div v-for="row in fileRows" :key="row.key" class="form-group row border-bottom pb-2">
 
                                 <template v-if="row.file">
                                     <label v-if=" row.file._id" class="col-sm-3 col-form-label" :title="row.file.filename">
@@ -151,18 +151,31 @@
                                     <div v-if="row.file" class="input-group">
                                         <div class="form-check">
                                             <input :disabled="!!progress || !row.file.allowPublic"  type="checkbox" class="form-check-input" :id="`public-${row.key}`" v-model="row.file.public" >
-                                            <label class="form-check-label" :for="`public-${row.key}`">Visible on website</label>
+                                            <label class="form-check-label" :for="`public-${row.key}`">Visible on website
+                                                <i v-if="!row.file.public" class="fa fa-eye-slash text-muted"></i>
+                                            </label>
                                         </div>
                                         <div class="form-check">
                                             <input :disabled="!!progress || !!row.file._id"  type="checkbox" class="form-check-input" :id="`allowPublic-${row.key}`" v-model="row.file.allowPublic" >
                                             <label class="form-check-label" :for="`allowPublic-${row.key}`">Participant allowed publication</label>
                                         </div>
                                     </div>
-                                    <div v-else class="col-form-label text-muted">
-                                        <div :title="row.message">{{ row.message }}</div>
-                                        <small v-if="row.willRequest" class="font-italic">
-                                            <i class="fa fa-exclamation-circle"></i> Translations are requested when you save.
-                                        </small>
+                                    <div v-else>
+                                        <div v-if="row.requestable" class="form-check"
+                                             :title="sourceAllowsPublic ? '' : 'Participant did not allow publication'">
+                                            <input :disabled="!!progress || !sourceAllowsPublic" type="checkbox" class="form-check-input"
+                                                   :id="`public-${row.key}`" :checked="row.public"
+                                                   @change="requestPublic[row.lang] = $event.target.checked">
+                                            <label class="form-check-label" :for="`public-${row.key}`">Visible on website
+                                                <i v-if="!row.public" class="fa fa-eye-slash text-muted"></i>
+                                            </label>
+                                        </div>
+                                        <div class="col-form-label text-muted">
+                                            <div :title="row.message">{{ row.message }}</div>
+                                            <small v-if="row.willRequest" class="font-italic">
+                                                <i class="fa fa-exclamation-circle"></i> Translations are requested when you save.
+                                            </small>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -184,6 +197,11 @@
                                             </a>
                                         </div>
                                     </div>
+                                    <button v-if="canAddEnglishForStaff" type="button" class="btn btn-light btn-sm ml-2"
+                                            :disabled="!!progress" @click="addEnglishForStaff"
+                                            title="Request an English translation for internal use - not visible on the website">
+                                        <i class="fa fa-eye-slash"></i> Add English for staff
+                                    </button>
                                 </div>
                             </div>
 
@@ -273,6 +291,9 @@ export default {
             translations:   { ...(this.intervention.translations||{}) },
             addedLangs:     [],   // languages added from the dropdown - extra rows, no file
             requestedLangs: [],   // the ticked set, across every requestable row
+            // `Visible on website` per requestable language - every language is seeded so v-model
+            // stays reactive, and a request defaults to public.
+            requestPublic:  Object.fromEntries(Object.keys(UN).map(lang => [lang, true])),
             now:            Date.now(),
             // Move intervention functionality
             availableSessions: [],
@@ -282,9 +303,9 @@ export default {
             sessionsError: null,
         }
     },
-    computed: { fileRows, sourceFile, missingLangs, langsToRequest, hasTranslations, canUpdateStatus, canPublish, canMove, sessionHasChanged, currentSessionDisplay },
+    computed: { fileRows, sourceFile, sourceAllowsPublic, missingLangs, canAddEnglishForStaff, langsToRequest, hasTranslations, canUpdateStatus, canPublish, canMove, sessionHasChanged, currentSessionDisplay },
     methods: { open, close, clearError, save, onOrganizationChange, isKronosUser, formatDate, languageName, loadAvailableSessions, formatSessionOption, toggleMoveEnabled,
-               liveEntry, buildRequestRow, onFileSelect, addLanguage, addAllLanguages, removeLanguage, requestTranslations },
+               liveEntry, buildRequestRow, onFileSelect, addLanguage, addAllLanguages, addEnglishForStaff, removeLanguage, requestTranslations },
     created,
     mounted,
     beforeDestroy,
@@ -329,6 +350,12 @@ function close(intervention){
 // brand-new intervention as soon as a file is picked - save() resolves the real id after upload.
 function sourceFile() {
     return this.files.find(f => !f.autoTranslated && (f._id || f.htmlFile)) || null;
+}
+
+// A translation inherits the source file's publication permission: mapFileData() already clamps a
+// file's `public` to its `allowPublic`, so a request must not ask for more than the original allows.
+function sourceAllowsPublic() {
+    return !!(this.sourceFile && this.sourceFile.allowPublic);
 }
 
 // Display order only - `files` keeps its server order so save() is unaffected. Virtual rows never
@@ -413,7 +440,16 @@ function buildRequestRow(lang, entry) {
         requestable,
         willRequest: requestable && this.requestedLangs.includes(lang),
         removable  : !entry,
+        public     : !!(this.requestPublic[lang] && this.sourceAllowsPublic),
     };
+}
+
+// `missingLangs` already encodes every condition the button needs: it is empty without a source
+// file, and it excludes the source language itself along with any language that already holds a
+// file or a translation entry - so English being in it means there is no English version to clash
+// with. It also drops out once the row has been added.
+function canAddEnglishForStaff() {
+    return this.missingLangs.includes('en');
 }
 
 function missingLangs() {
@@ -429,7 +465,7 @@ function missingLangs() {
 // gated on `requestable`, so a language protected by a human file, a still-fresh pending, or the
 // current source language can never be sent even if it lingers in `requestedLangs`.
 function langsToRequest() {
-    return this.fileRows.filter(r => r.willRequest).map(r => r.lang);
+    return this.fileRows.filter(r => r.willRequest).map(r => ({ lang: r.lang, public: r.public }));
 }
 
 // $set, not assignment: `htmlFile` is absent from a seeded file row, and `sourceFile` - which gates
@@ -445,6 +481,13 @@ function addLanguage(lang) {
 
 function addAllLanguages() {
     this.missingLangs.forEach(this.addLanguage);
+}
+
+// Same row the dropdown's `English` entry produces, but hidden from the website: the secretariat
+// reads it internally. The checkbox stays editable, so it can still be published from the row.
+function addEnglishForStaff() {
+    this.addLanguage('en');
+    this.requestPublic.en = false;
 }
 
 function removeLanguage(lang) {
@@ -621,12 +664,12 @@ async function save(publish=false){
 // ids back into `files`, so the source file has an id even on a brand-new intervention.
 async function requestTranslations(interventionId, updatedIntervention) {
 
-    const langs = this.langsToRequest;
+    const requests = this.langsToRequest;
 
-    if(!langs.length) return;
+    if(!requests.length) return;
 
-    const results = await Promise.all(langs.map(lang =>
-        this.api.requestInterventionFileTranslation(interventionId, this.sourceFile._id, lang)
+    const results = await Promise.all(requests.map(({ lang, public: isPublic }) =>
+        this.api.requestInterventionFileTranslation(interventionId, this.sourceFile._id, lang, isPublic)
             .then(status => ({ lang, status }))
             .catch(err   => ({ lang, error: (err && (err.message || err.code)) || 'Request failed' }))
     ));

--- a/app/components/meetings/sessions/edit-intervention-modal.vue
+++ b/app/components/meetings/sessions/edit-intervention-modal.vue
@@ -253,6 +253,7 @@ import OrganizationSearch from './organization-search.vue'
 import DateTimeSelector   from './datetime-selector.vue'
 import { format as formatDate, timezone, asDateTime } from '../datetime.js'
 import { UN, getLanguageName as languageName } from '~/data/languages'
+import { detectFilenameLanguage } from '~/util/language-detect.js'
 
 // A freshly requested translation is left alone: `Request` only reappears on a pending row once the
 // entry is older than this.
@@ -470,8 +471,17 @@ function langsToRequest() {
 
 // $set, not assignment: `htmlFile` is absent from a seeded file row, and `sourceFile` - which gates
 // the language dropdown - has to react to the pick.
-function onFileSelect(file, event) {
-    this.$set(file, 'htmlFile', event.target.files[0]);
+async function onFileSelect(file, event) {
+    const htmlFile = event.target.files[0];
+
+    this.$set(file, 'htmlFile', htmlFile);
+
+    if(!htmlFile)            return;
+    if(this.hasTranslations) return;   // the select is locked; changing it would orphan `translations`
+
+    const language = await detectFilenameLanguage(htmlFile.name);
+
+    if(language) file.language = language;
 }
 
 function addLanguage(lang) {

--- a/app/components/meetings/sessions/files-view.vue
+++ b/app/components/meetings/sessions/files-view.vue
@@ -13,7 +13,7 @@
           <span v-for="file in group" :key="file._id">
             <a :href="file.autoTranslated ? '#' : file.url" :target="file.autoTranslated ? null : '_blank'"
                @click="onFileClick(file, $event)">
-              <span class="language">
+              <span class="language" :class="{ 'text-muted mr-0': !file.public }">
                 <span class="d-none d-lg-inline">{{ file.language| langTextFilter }}</span>
                 <span class="d-lg-none">{{ file.language }}</span>
               </span>

--- a/app/components/meetings/upload-statement-dialog.vue
+++ b/app/components/meetings/upload-statement-dialog.vue
@@ -105,15 +105,16 @@
                             <div class="form-group row">
                                 <label for="fileLanguage" class="col-sm-3 col-form-label">Language</label>
                                 <div class="col-sm-9">
-                                    <select :disabled="!!progress" class="form-control" id="fileLanguage" v-model="selectedLanguage">
+                                    <select :disabled="!!progress" class="form-control" id="fileLanguage" v-model="selectedLanguage" required>
                                         <option value="ar">العربية</option>
-                                        <option value="en" selected>English</option>
+                                        <option value="en">English</option>
                                         <option value="es">Español</option>
                                         <option value="fr">Français</option>
                                         <option value="ru">Русский</option>
                                         <option value="zh">中文</option>
                                     </select>
-                                </div>        
+                                    <div class="invalid-feedback">Please select the language of the file.</div>
+                                </div>
                             </div>       
                             
                             <!-- DISABLED
@@ -199,7 +200,7 @@ export default {
             file                : null,
             meetings            : [],
             selectedAgendaItem  : null,
-            selectedLanguage    : "en",
+            selectedLanguage    : null,
             selectedRegion      : null,
             isRegional          : false,
             allowPublic         : true,
@@ -419,7 +420,7 @@ export default {
             this.$refs.file.value    = null;
             this.file                = null;
             this.selectedAgendaItem  = null;
-            this.selectedLanguage    = "en",
+            this.selectedLanguage    = null,
             this.selectedRegion      = null;
             this.isRegional          = false;
             this.allowPublic         = true;

--- a/app/components/meetings/upload-statement-dialog.vue
+++ b/app/components/meetings/upload-statement-dialog.vue
@@ -182,6 +182,7 @@ import $    from 'jquery';
 import i18n from './locales.js'
 import Api  from './api.js'
 import remapCode  from './sessions/re-map.js'
+import { detectFilenameLanguage } from '~/util/language-detect.js'
 
 const captchaSiteKeyV2 = (document && document.documentElement.attributes['captcha-site-key-v2'].value);
 
@@ -313,8 +314,12 @@ export default {
             if(visible) this.init();            
         },
   
-        onFileChange(files) {
+        async onFileChange(files) {
             this.file = files[0]
+
+            const language = this.file && await detectFilenameLanguage(this.file.name);
+
+            if(language) this.selectedLanguage = language;
         },
         clearError() {
             this.$refs.participantIdentity.setCustomValidity("")

--- a/app/util/language-detect.js
+++ b/app/util/language-detect.js
@@ -1,0 +1,40 @@
+import loadFranc from 'franc'
+
+// ISO 639-3 (franc's output) and 639-2/B aliases -> the six UN languages of `~/data/languages`.
+const UN_LANGUAGE = { ara:'ar', arb:'ar', eng:'en', spa:'es', esp:'es',
+                      fra:'fr', fre:'fr', rus:'ru', cmn:'zh', zho:'zh', chi:'zh' };
+
+const UN_CODES = new Set(Object.values(UN_LANGUAGE));
+
+// Exported: a caller holding an explicit code (a `-fra` suffix) needs the same table.
+export function toUnLanguage(code) {
+    code = (code||'').toLowerCase();
+
+    return UN_CODES.has(code) ? code : (UN_LANGUAGE[code] || null);
+}
+
+// null when franc cannot tell (`und`), names a language we do not publish, or fails to load - the
+// caller picks the default. franc's 10-character minimum is tuned for prose and rejects short
+// Chinese and Arabic outright, so it is lowered.
+export async function detectLanguage(text) {
+    if(!text) return null;
+
+    const franc = await loadFranc().catch(() => null);
+
+    return franc ? toUnLanguage(franc(text, { minLength: 3 })) : null;
+}
+
+// AI translations carry an `.ai` marker before the extension: `my-file-name-en.ai.docx`.
+const AI_MARKER = /\.ai(?=\.)/i;
+const EXTENSION = /\.[^.]+$/;
+
+// `-fr`, `-eng`: an explicit suffix is trusted over detection. One that is not a UN language
+// (`-rev`, `-final`) falls through instead of blocking it.
+const LANGUAGE_SUFFIX = /-([a-z]{2,3})$/i;
+
+export async function detectFilenameLanguage(filename) {
+    const basename   = (filename||'').replace(AI_MARKER, '').replace(EXTENSION, '');
+    const [, suffix] = basename.match(LANGUAGE_SUFFIX) || [];
+
+    return toUnLanguage(suffix) || await detectLanguage(basename.replace(/[-_]+/g, ' '));
+}


### PR DESCRIPTION
Three related changes to statement handling in the meeting-session views.

**Website visibility on translation requests** — the request API now takes a `public` flag, so each requestable language gets its own **Visible on website** checkbox (default on, forced off when the participant did not allow publication). Adds an **Add English for staff** shortcut that queues a non-public English request, and an eye-slash marker wherever a file is not visible.

**Language detection from the filename** — picking a file preselects its language in both the staff modal and the participant upload dialog. A `-fr` / `-eng` suffix wins outright; otherwise the basename goes through franc, narrowed to the six UN languages, and the selection is left alone when nothing maps. franc ships no AMD build, so `boot.js` registers it as a lazy loader over the jsDelivr ESM bundle — nothing is fetched until a detection needs it.

**No default upload language** — the participant dialog's language select no longer defaults to English, removing the risk of uploading under an unnoticed default.

### Testing
Detection was verified against real franc output for suffix, Latin, Cyrillic, Arabic and Han filenames. The rest is unverified in a browser — worth exercising the request flow and confirming the CDN bundle loads once on first detection.