### PR TITLE
Statement visibility is preset, not derived - plus an upload confirmation

### DIFF
--- a/app/components/meetings/sessions/edit-intervention-modal.vue
+++ b/app/components/meetings/sessions/edit-intervention-modal.vue
@@ -315,12 +315,11 @@ export default {
 async function created() {
   this.api = new Api(this.tokenReader)
 
+  // Publishing only moves the intervention to `Delivered`: each file keeps the visibility already
+  // set on it, so a file deliberately kept off the website stays off it.
   if(this.action=='publish') {
       this.datetime = new Date();
       this.status   = 'public';
-      this.files.forEach(f => {
-          f.public = !!f.allowPublic;
-      });
   }
 
   this.organizationTypes = await this.api.getInterventionOrganizationTypes();

--- a/app/components/meetings/sessions/edit-intervention-modal.vue
+++ b/app/components/meetings/sessions/edit-intervention-modal.vue
@@ -150,20 +150,15 @@
                                 <div class="col-sm-5">
                                     <div v-if="row.file" class="input-group">
                                         <div class="form-check">
-                                            <input :disabled="!!progress || !row.file.allowPublic"  type="checkbox" class="form-check-input" :id="`public-${row.key}`" v-model="row.file.public" >
+                                            <input :disabled="!!progress"  type="checkbox" class="form-check-input" :id="`public-${row.key}`" v-model="row.file.public" >
                                             <label class="form-check-label" :for="`public-${row.key}`">Visible on website
                                                 <i v-if="!row.file.public" class="fa fa-eye-slash text-muted"></i>
                                             </label>
                                         </div>
-                                        <div class="form-check">
-                                            <input :disabled="!!progress || !!row.file._id"  type="checkbox" class="form-check-input" :id="`allowPublic-${row.key}`" v-model="row.file.allowPublic" >
-                                            <label class="form-check-label" :for="`allowPublic-${row.key}`">Participant allowed publication</label>
-                                        </div>
                                     </div>
                                     <div v-else>
-                                        <div v-if="row.requestable" class="form-check"
-                                             :title="sourceAllowsPublic ? '' : 'Participant did not allow publication'">
-                                            <input :disabled="!!progress || !sourceAllowsPublic" type="checkbox" class="form-check-input"
+                                        <div v-if="row.requestable" class="form-check">
+                                            <input :disabled="!!progress" type="checkbox" class="form-check-input"
                                                    :id="`public-${row.key}`" :checked="row.public"
                                                    @change="requestPublic[row.lang] = $event.target.checked">
                                             <label class="form-check-label" :for="`public-${row.key}`">Visible on website
@@ -304,7 +299,7 @@ export default {
             sessionsError: null,
         }
     },
-    computed: { fileRows, sourceFile, sourceAllowsPublic, missingLangs, canAddEnglishForStaff, langsToRequest, hasTranslations, canUpdateStatus, canPublish, canMove, sessionHasChanged, currentSessionDisplay },
+    computed: { fileRows, sourceFile, missingLangs, canAddEnglishForStaff, langsToRequest, hasTranslations, canUpdateStatus, canPublish, canMove, sessionHasChanged, currentSessionDisplay },
     methods: { open, close, clearError, save, onOrganizationChange, isKronosUser, formatDate, languageName, loadAvailableSessions, formatSessionOption, toggleMoveEnabled,
                liveEntry, buildRequestRow, onFileSelect, addLanguage, addAllLanguages, addEnglishForStaff, removeLanguage, requestTranslations },
     created,
@@ -350,12 +345,6 @@ function close(intervention){
 // brand-new intervention as soon as a file is picked - save() resolves the real id after upload.
 function sourceFile() {
     return this.files.find(f => !f.autoTranslated && (f._id || f.htmlFile)) || null;
-}
-
-// A translation inherits the source file's publication permission: mapFileData() already clamps a
-// file's `public` to its `allowPublic`, so a request must not ask for more than the original allows.
-function sourceAllowsPublic() {
-    return !!(this.sourceFile && this.sourceFile.allowPublic);
 }
 
 // Display order only - `files` keeps its server order so save() is unaffected. Virtual rows never
@@ -440,7 +429,7 @@ function buildRequestRow(lang, entry) {
         requestable,
         willRequest: requestable && this.requestedLangs.includes(lang),
         removable  : !entry,
-        public     : !!(this.requestPublic[lang] && this.sourceAllowsPublic),
+        public     : !!this.requestPublic[lang],
     };
 }
 
@@ -696,16 +685,12 @@ async function requestTranslations(interventionId, updatedIntervention) {
                       + failed.map(f => `${languageName(f.lang)} (${f.error})`).join(', '));
 }
 
+// `allowPublic` is stripped along with the local-only fields: files fetched from the server may still
+// carry the retired flag, and it must not be echoed back.
 function mapFileData(file) {
-    let { allowPublic, public: isPublic } = file;
-
-    allowPublic = allowPublic || false;
-    isPublic    = isPublic    && allowPublic;
-
     const data = {
         ...file,
-        allowPublic,
-        public : isPublic,
+        allowPublic: undefined,
         htmlFile: undefined,
         text: undefined
     }

--- a/app/components/meetings/sessions/edit.vue
+++ b/app/components/meetings/sessions/edit.vue
@@ -203,7 +203,7 @@ async function init(){
 function createPendingIntervention(){
   this.edit({ 
     status: 'pending',
-    files : [ { language: 'en', allowPublic: true, public: true} ]
+    files : [ { language: 'en', public: true} ]
   });
 }
 

--- a/app/components/meetings/sessions/files-view.vue
+++ b/app/components/meetings/sessions/files-view.vue
@@ -18,7 +18,7 @@
                 <span class="d-lg-none">{{ file.language }}</span>
               </span>
             </a>
-            <i v-if="!file.public" class="fa fa-eye-slash" :class="{ 'text-success' : file.allowPublic, 'text-muted': !file.allowPublic}"/>
+            <i v-if="!file.public" class="fa fa-eye-slash text-muted"/>
           </span>
         </div>
     </div>

--- a/app/components/meetings/upload-statement-dialog.vue
+++ b/app/components/meetings/upload-statement-dialog.vue
@@ -117,25 +117,6 @@
                                 </div>
                             </div>       
                             
-                            <!-- DISABLED
-                            <div class="form-group row">
-                                <label for="allowPublic" class="col-sm-3 col-form-label">Do you allow public access?</label>
-                                <div class="col-sm-9">
-                                    <div class="input-group">
-                                        <select :disabled="!!progress" class="form-control" id="allowPublic" v-model="allowPublic" required> 
-                                            <optgroup>
-                                                <option value="true">Yes - I allow publication of this file on the CBD website (publicly available upon validation)</option>
-                                                <option value="false">No  - Do not publish this file on CBD website (Secretariat and interpreters access only)</option>
-                                            </optgroup>
-                                        </select>                                    
-                                        <div class="input-group-append">
-                                            <span class="input-group-text" data-toggle="tooltip" data-placement="auto" title="If you select `yes` you grant permission to the Secretariat to publish this document publicly on its website"><i class="fa fa-question-circle"></i></span>
-                                        </div>      
-                                        <div class="invalid-feedback">Please select if you allow publication of you file on website.</div>
-                                    </div>
-                                </div>
-                            </div>  
-                            -->
                             <div class="form-group row">
                                 <div class="col-sm-3"></div>
                                 <div class="col-sm-9 input-group">
@@ -203,7 +184,6 @@ export default {
             selectedLanguage    : null,
             selectedRegion      : null,
             isRegional          : false,
-            allowPublic         : true,
             participantIdentity : '',
             rememberMe          : false,
             wasValidated        : false,
@@ -247,8 +227,7 @@ export default {
                 && !!this.cleanParticipantIdentity
                 && !!this.selectedAgendaItem
                 && !!this.selectedLanguage
-                && (!this.isRegional || !!this.selectedRegion)
-                &&   this.allowPublic!==null;
+                && (!this.isRegional || !!this.selectedRegion);
         },
         cleanParticipantIdentity(){ 
             return this.participantIdentity.replace(/[^a-z0-9]/gi, "").toUpperCase();
@@ -342,7 +321,6 @@ export default {
                 contentType : this.file.type,
                 agendaItem  : Number(this.selectedAgendaItem.item) || undefined,
                 language    : this.selectedLanguage,
-                allowPublic : this.allowPublic===true || this.allowPublic==='true',
                 region      : this.isRegional ? this.selectedRegion : null
             }
 
@@ -423,7 +401,6 @@ export default {
             this.selectedLanguage    = null,
             this.selectedRegion      = null;
             this.isRegional          = false;
-            this.allowPublic         = true;
             this.persistIdentity();
 
             if(localStorage.participantIdentity) {

--- a/app/components/meetings/upload-statement-dialog.vue
+++ b/app/components/meetings/upload-statement-dialog.vue
@@ -29,7 +29,12 @@
                             </div>
                         </div>
 
-                        <form v-show="!confirmEarlyPublish" id="statement-submission-form" @submit.prevent="submitForm" enctype="multipart/form-data" ref="form" novalidate :class="{ 'was-validated': wasValidated }">
+                        <div v-if="submitted" class="text-center py-4">
+                            <p class="lead"><i class="fa fa-check-circle text-success"></i> Your statement has been uploaded successfully.</p>
+                            <small class="text-muted">{{ submittedFilename }}</small>
+                        </div>
+
+                        <form v-show="!confirmEarlyPublish && !submitted" id="statement-submission-form" @submit.prevent="submitForm" enctype="multipart/form-data" ref="form" novalidate :class="{ 'was-validated': wasValidated }">
 
                             <div class="form-group row">
                                 <label for="participantIdentity" class="col-sm-3 col-form-label">Priority-Pass or Badge Code</label>
@@ -147,7 +152,9 @@
                             </div>
                         </span>
 
-                        <template v-if="!confirmEarlyPublish">
+                        <button v-if="submitted" type="button" class="btn btn-default" @click="close()"><i class="fa fa-power-off"></i> <span>Close ({{closeCountdown}})</span></button>
+
+                        <template v-else-if="!confirmEarlyPublish">
                             <button :disabled="!!progress" type="submit" class="btn btn-success" @click="submitForm"><i class="fa fa-upload"></i> <span>Submit</span></button>
                             <button :disabled="!!progress" type="button" class="btn btn-default" @click="close()"><i class="fa fa-power-off"></i> <span class="hidden-xs">Close</span></button>
                         </template>
@@ -191,6 +198,9 @@ export default {
             error               : null,
             grecaptchaToken     : undefined,
             confirmEarlyPublish : false,
+            submitted           : false,
+            submittedFilename   : '',
+            closeCountdown      : 0,
             slot                : null,
             uploadPromise       : null
         }
@@ -207,6 +217,9 @@ export default {
 
         $('[data-toggle="tooltip"]').tooltip();
         this.openDialog(this.show);
+    },
+    beforeDestroy(){
+        clearInterval(this.closeTimer);
     },
     watch: {
         show(visible) { this.openDialog(visible) },
@@ -348,7 +361,7 @@ export default {
             this.$emit("notify", `Your file "${this.slot.metadata.filename}" has been submitted successfully`);
             this.progress     = null;
             this.wasValidated = false;
-            this.close();
+            this.showSubmitted();
 
           } catch(err) {
             if(err.code=='forbidden') this.$refs.participantIdentity.setCustomValidity("Invalid badge or priority-pass number")
@@ -376,7 +389,7 @@ export default {
             this.$emit("notify", `Your file "${this.slot.metadata.filename}" has been submitted successfully`);
             this.progress     = null;
             this.wasValidated = false;
-            this.close();
+            this.showSubmitted();
 
           } catch(err) {
             await this.$nextTick();
@@ -388,7 +401,22 @@ export default {
             this.grecaptchaToken = undefined;
           }
         },
+        // The name of the file the participant picked, not the server's - which may have renamed it.
+        // It is copied because resetForm() clears `file` when the dialog closes, and the confirmation
+        // stays on screen until then.
+        showSubmitted(){
+            this.submitted         = true;
+            this.submittedFilename = this.file.name || this.slot.metadata.filename;
+            this.closeCountdown    = 10;
+
+            clearInterval(this.closeTimer);
+            this.closeTimer = setInterval(() => {
+                if(--this.closeCountdown <= 0) this.close();   // close() resets the form, clearing this timer
+            }, 1000);
+        },
         resetForm(){
+            clearInterval(this.closeTimer);
+            this.submitted           = false;
             this.wasValidated        = false;
             this.error               = null;
             this.uploading           = false;


### PR DESCRIPTION
## What

Three related changes to how a statement file's website visibility is decided, and a confirmation screen for participants.

### 1. Publishing no longer rewrites file visibility
Switching an intervention from `Uploaded / Pending` to `Delivered` reset every file's `Visible on website` from `allowPublic`, silently republishing a file the secretariat had deliberately hidden. Publishing now only moves the intervention to `Delivered` - the visibility is whatever was preset on each file (participant upload, per-language translation request, or the checkbox in the modal).

### 2. `allowPublic` is retired
The flag recorded whether the participant authorized publication and gated the `Visible on website` control everywhere. It is gone from the frontend:

- the participant upload no longer sends it (the question itself had already been disabled)
- the edit modal loses the `Participant allowed publication` checkbox and no longer clamps `public` to it
- translation requests are no longer gated by the source file's flag
- `mapFileData()` strips the field, so a value still stored on an existing file is not echoed back
- the eye-slash marker in the files view was green when publication had been authorized; it is now always muted

`Visible on website` is the only visibility control left.

### 3. Statement upload confirmation
The dialog closed the instant the upload committed, leaving the participant with only a page-level alert behind the modal. It now shows a check, the name of the file they picked, and a `Close (10)` button that counts down and closes itself.

## Backend note

gaia now receives no `allowPublic` on `POST api/v2021/meeting-interventions/slot`. If the server still clamps a file's `public` to a stored `allowPublic` that defaults to `false`, participant statements will stay hidden until the backend drops the flag too.

## Testing

- Templates and scripts of all four touched components compile at each of the three commits.
- Not exercised in a running app.