### PR TITLE
fix(UI): Honour the time of day in schedule datetime overrides

### DIFF
--- a/app/views/meetings/documents/agenda.html
+++ b/app/views/meetings/documents/agenda.html
@@ -59,7 +59,7 @@
                     <a class="nav-link btn dropdown-toggle" ng-class="{ 'btn-danger' : agendaCtrl.isDateOverride }" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" ng-href="#" style="border:1px solid #f5efef">
                         <em class="visible-xs-inline1 fa fa-clock-o"></em> 
                         <b ng-if="!agendaCtrl.isDateOverride" ng-bind="agendaCtrl.now | moment:'tz':agendaCtrl.getTimezone() | moment:'format':'H:mm'"></b>
-                        <b ng-if=" agendaCtrl.isDateOverride" ng-bind="agendaCtrl.now | moment:'tz':agendaCtrl.getTimezone() | moment:'format':'MMM Do'"></b>
+                        <b ng-if=" agendaCtrl.isDateOverride" ng-bind="agendaCtrl.now | moment:'tz':agendaCtrl.getTimezone() | moment:'format':agendaCtrl.dateOverrideFormat()"></b>
                     </a>
             		<div class="dropdown-menu dropdown-menu-right">
             			<a class="text-nowrap dropdown-item" href="#" ng-repeat="item in agendaCtrl.scheduleDates" ng-click="agendaCtrl.scheduleDateChanged(item.value)">

--- a/app/views/meetings/documents/agenda.js
+++ b/app/views/meetings/documents/agenda.js
@@ -121,6 +121,17 @@ export default ["$scope", "$route", "$http", '$q', '$interval', 'conferenceServi
         }
 
         //==============================
+        // a date-only override lands on midnight, so it carries no time worth showing
+        //==============================
+        function dateOverrideFormat() {
+
+            var atMidnight = moment.tz(_ctrl.now, getTimezone()).format('HH:mm:ss') == '00:00:00';
+
+            return atMidnight ? 'MMM Do' : 'MMM Do H:mm';
+        }
+        _ctrl.dateOverrideFormat = dateOverrideFormat
+
+        //==============================
         //
         //==============================
         function load() {

--- a/app/views/schedules/index-id.html
+++ b/app/views/schedules/index-id.html
@@ -91,7 +91,7 @@
                                             moment:'tz':scheduleCtrl.getTimezone() | moment:'format':'ddd MMM DD'}}</b></div>
 
 
-                                    <schedule-time ng-vue="vueOptions" ng-vue-expose="r" :start="r.start" :end="r.end" :timezone="timezone" />
+                                    <schedule-time ng-vue="vueOptions" ng-vue-expose="r" :start="r.start" :end="r.end" :timezone="scheduleCtrl.timezone" />
                                     
                                     <div class="small badge" ng-class="{'badge-success':r.open, 'badge-danger':!r.open }">
                                         <span ng-show="r.open" title="Open to everyone">Open</span>

--- a/app/views/schedules/index-id.js
+++ b/app/views/schedules/index-id.js
@@ -42,7 +42,12 @@ export default ['$scope', '$http', '$route', '$q', 'streamId', 'conferenceServic
         $scope.route      = { params : $route.current.params, query: $location.search() }
         $scope.vueOptions  = { components: { AgendaItem, ScheduleTime } };
 
-        load();
+        // the datetime route param is expressed in conference time, so the timezone must be
+        // known before the first load() parses it. The hosting view has already resolved the
+        // conference, so this is served from the service cache.
+        $q.when(conferenceService.getActiveConference())
+          .then(function(conference){ _ctrl.timezone = conference?.timezone })
+          .then(load);
 
 		//========================================
 		//
@@ -52,7 +57,7 @@ export default ['$scope', '$http', '$route', '$q', 'streamId', 'conferenceServic
             const expandedReservationIds = _(_ctrl.frames).map(f=>f.reservations||[]).flatten().filter(r=>r.expand).map(r=>r._id).value();
 
             const dateTimeString = $route.current.params.datetime || $location.search().datetime; 
-            const dateTime       = dateTimeString ? moment.tz(dateTimeString, getTimezone()).startOf('day').toISOString() : null;
+            const dateTime       = dateTimeString ? moment.tz(dateTimeString, getTimezone()).toISOString() : null;
             var streamId         = $route.current.params.streamId || defaultStreamId;
 
             var options  = dateTime ? { params : { cache:true, datetime: dateTime } } : { params : { cache:true } };
@@ -72,13 +77,12 @@ export default ['$scope', '$http', '$route', '$q', 'streamId', 'conferenceServic
 
             }).then(async function(conf){
                 _ctrl.institution        = conf.institution;
-                _ctrl.conferenceTimezone = conf.timezone;
+                _ctrl.timezone           = conf.timezone;
                 _ctrl.code               = conf.code
                 _ctrl.showRooms          = conf.schedule.showRooms
                 _ctrl.uploadStatement    = conf.uploadStatement;
 
                 $scope.schedule = conf.schedule
-                $scope.timezone = conf.timezone
 
                 if($route.current.params.datetime)
                     options.params.datetime = _ctrl.now();
@@ -113,10 +117,8 @@ export default ['$scope', '$http', '$route', '$q', 'streamId', 'conferenceServic
                 var rooms = _.reduce(res[1].data, function(ret, r){ ret[r._id] = r; return ret; }, {});
                 const meetings = res[2].data
 
-                _ctrl.conferenceTimezone = _streamData.eventGroup.timezone;
                 _ctrl.event              = _streamData.eventGroup;
                 _ctrl.frames             = _streamData.frames;
-                _ctrl.timezone           = _streamData.eventGroup.timezone;
 
                 const hasRole = isAdmin()
                 const statementEnabledMeetings = meetings.filter(m=>m.uploadStatement).map(m=>m.EVT_CD);
@@ -230,7 +232,7 @@ export default ['$scope', '$http', '$route', '$q', 'streamId', 'conferenceServic
         }
 
         function getTimezone() {
-          return  _ctrl.conferenceTimezone 
+          return  _ctrl.timezone
         }
         _ctrl.getTimezone = getTimezone
 


### PR DESCRIPTION
## Problem

The schedule view (`views/schedules/index-id`, embedded in the meeting agenda's *Overview* tab) mishandled the `datetime` override in two ways:

1. **Parsed in the wrong timezone.** `load()` reads the `datetime` route/query param and parses it with `moment.tz(dateTimeString, getTimezone())`, but on the first load the timezone was still `undefined` - it was only assigned from the API response that same call is about to make. `moment.tz` with an undefined zone falls back to the browser's timezone, so `?datetime=2026-07-31` resolved to midnight *in the viewer's zone*, not at the venue.
2. **Time of day discarded.** The parsed value was flattened with `.startOf('day')` before being sent to the API, so a time-bearing override such as `?datetime=2026-07-31T14:30` behaved identically to the bare date.

## Changes

**Resolve the timezone before the first load** - `app/views/schedules/index-id.js`

`conferenceService.getActiveConference()` now runs before `load()`. The service memoizes the conference in a closure and returns `$q.when(meeting)` on repeat calls, and the hosting view (`views/meetings/documents/agenda`) has already resolved it before this view is even instantiated - the `view-injector` sits inside the cctv tab pane, gated on state that is only set after that resolve. So this is a cache hit: **no additional HTTP request**. `conferenceService` was already in the controller's DI list, unused.

Called with no `code` argument on purpose - the service only invalidates its cache when a *mismatching* code is passed, so the argument-less call is guaranteed to reuse the parent's object.

**Keep the override's time of day** - `app/views/schedules/index-id.js`

Dropped `.startOf('day')` so the time survives to the API call.

**Show the time in the date-override badge** - `app/views/meetings/documents/agenda.{js,html}`

New `dateOverrideFormat()` returns `MMM Do` for a midnight override and `MMM Do H:mm` otherwise. Midnight is tested in venue time (`_ctrl.now` is a `Date`, so the zone is re-applied before formatting) - testing browser-local time would show a spurious time on every date-only override. `H:mm` matches the non-override branch on the line above.

**Collapse three copies of the timezone into one** - `app/views/schedules/index-id.{js,html}`

The controller held the same `eventGroup.timezone` value in three places: `_ctrl.conferenceTimezone` (read by `getTimezone()`), `$scope.timezone` (bound into the `<schedule-time>` Vue component), and `_ctrl.timezone` (dead - nothing referenced `scheduleCtrl.timezone`), plus a redundant re-assignment of `conferenceTimezone` in a later `.then`. All merged onto `_ctrl.timezone`; the template binding became `:timezone="scheduleCtrl.timezone"`.

## Testing

Not verified in a browser - this checkout can't build the bundle (`angular-vue` and Angular are absent from `node_modules`). Reviewer spot-check, on the agenda *Overview* tab:

| URL                              | Expected badge          | Expected schedule            |
| -------------------------------- | ----------------------- | ---------------------------- |
| no `datetime`                     | live clock, `H:mm`      | current day at venue         |
| `?datetime=2026-07-31`            | `Jul 31st`              | that day in **venue** time   |
| `?datetime=2026-07-31T14:30`      | `Jul 31st 14:30`        | that day, from 14:30 onward  |

The timezone-merge change is behaviour-neutral; the one runtime-resolved piece is the `:timezone="scheduleCtrl.timezone"` binding, so it's worth confirming the time column still renders in venue timezone.

## Notes

No Jira ticket for this one.