### PR TITLE
fix(UI): Sort a document ahead of its own annexes

### DIFF
--- a/app/services/meetings.js
+++ b/app/services/meetings.js
@@ -39,6 +39,10 @@ export function normalizeDocumentSymbol(symbol) {
     return symbol.toUpperCase().replace(/[^A-Z0-9\/\-\*]/gi, '').replace(/\/$/g, '');
 }
 
+// Sorts below every printable character and cannot occur in symbols, titles or ids,
+// so a field boundary always compares lower than field content.
+export const SORT_KEY_SEPARATOR = '\u0001';
+
 const Priorities_Type = {
     'official'       : 1,
     'information'    : 2,
@@ -101,7 +105,7 @@ export function documentSortKey(d, { baseSymbol, locale } ) {
     parts.push(`ID`);
     parts.push((d._id||'').toUpperCase());
 
-    const key = parts.join('-').replace(/\d+/g, (t)=>pad(t));;
+    const key = parts.join(SORT_KEY_SEPARATOR).replace(/\d+/g, (t)=>pad(t));
 
     // d.title.en = key;
 

--- a/app/views/meetings/documents/in-session-documents.js
+++ b/app/views/meetings/documents/in-session-documents.js
@@ -14,8 +14,8 @@ export { default as template }  from './in-session-documents.html'
 
 var STATISTICS = {}; 
 
-export default ["$scope", "$route", "$http", '$q', '$location', 'authentication', 'conferenceService', '$filter', 'CacheFactory', function(
-              $scope,   $route,   $http,   $q,   $location,   authentication,   conferenceService,   $filter,   CacheFactory) {
+export default ["$scope", "$route", "$http", '$q', '$location', 'authentication', 'conferenceService', '$filter', 'CacheFactory', 'locale', function(
+              $scope,   $route,   $http,   $q,   $location,   authentication,   conferenceService,   $filter,   CacheFactory,   locale) {
         
         var $ctrl = $scope.$ctrl = this;
         var lstring  = $filter('lstring');
@@ -82,7 +82,8 @@ export default ["$scope", "$route", "$http", '$q', '$location', 'authentication'
                 const meetings = await qMeetings;
                 const documents = await qDocuments;
 
-                var tabs = _(documents).sortBy(buildSortKey).reduce(function(tabs, d){
+                // Documents span every meeting of the conference, so there is no single baseSymbol
+                var tabs = _(documents).sortBy(d => buildSortKey(d, { locale })).reduce(function(tabs, d){
 
                     d.agendaItems = (d.agendaItems||[]).map(i=>{
                         const meeting = meetings.find(m=>m._id == d.meeting);

--- a/app/views/meetings/documents/management/document-id.js
+++ b/app/views/meetings/documents/management/document-id.js
@@ -8,7 +8,7 @@ import '../meeting-document';
 import _ from 'lodash';
 import moment from 'moment';
 import displayGroups from '../display-groups';
-import { normalizeDocumentSymbol as normalizeSymbol } from '~/services/meetings';
+import { normalizeDocumentSymbol as normalizeSymbol, SORT_KEY_SEPARATOR } from '~/services/meetings';
 
 export { default as template } from './document-id.html';
 
@@ -1020,10 +1020,10 @@ export { default as template } from './document-id.html';
             else if(d.type=="other")                                 typePos = 60;
             else if(d.type=='in-session' && d.nature=="statement")   typePos = 70;
 
-            return ("000000000" + (typePos   ||9999)).slice(-9) + '_' + // pad with 0 eg: 150  =>  000000150
-                   (d.group||'') + '_' +
-                 //  ((d.metadata||{}).superseded ? '1' : '0') + '_' +
-                   ("000000000" + (d.displayPosition||9999)).slice(-9) + '_' + // pad with 0 eg: 150  =>  000000150
+            return ("000000000" + (typePos   ||9999)).slice(-9) + SORT_KEY_SEPARATOR + // pad with 0 eg: 150  =>  000000150
+                   (d.group||'') + SORT_KEY_SEPARATOR +
+                 //  ((d.metadata||{}).superseded ? '1' : '0') + SORT_KEY_SEPARATOR +
+                   ("000000000" + (d.displayPosition||9999)).slice(-9) + SORT_KEY_SEPARATOR + // pad with 0 eg: 150  =>  000000150
                    (d.symbol||"").replace(/\b(\d)\b/g, '0$1')
                                  .replace(/(\/REV)/gi, '0$1')
                                  .replace(/(\/ADD)/gi, '1$1');

--- a/app/views/schedules/index-id.js
+++ b/app/views/schedules/index-id.js
@@ -8,6 +8,7 @@ import '~/filters/moment'
 import '~/filters/html-sanitizer'
 import '~/services/conference-service'
 import { Plenary, WorkingGroupI, WorkingGroupII, HighLevelSegment   } from '~/util/meetings-data';
+import { SORT_KEY_SEPARATOR } from '~/services/meetings';
 import AgendaItem from '~/components/meetings/sessions/agenda-item.vue'
 import ScheduleTime from './schedule-time.vue';
 
@@ -216,7 +217,7 @@ export default ['$scope', '$http', '$route', '$q', 'streamId', 'conferenceServic
             var roomPriority =  r?.room?.title || '';
             var titlePriority=  r?.title || '';
 
-            return `${timePriority}-${typePriority}-${roomPriority}-${titlePriority}`.toLowerCase();
+            return [timePriority, typePriority, roomPriority, titlePriority].join(SORT_KEY_SEPARATOR).toLowerCase();
         }
 
         function now() {


### PR DESCRIPTION
## Details

`CBD/SBSTTA/27/INF/6-ANNEX-A` sorted **before** `CBD/SBSTTA/27/INF/6`.

`documentSortKey` joined its fields with `-`, but `-` is also legal inside a document symbol, so the field boundary was indistinguishable from field content. The annex suffix ended up compared against the literal `TITLE` field marker, and `'A' < 'T'`.

Fixed by joining on a reserved separator (U+0001) that sorts below every printable character and cannot occur in a symbol, title or id. That restores plain prefix ordering, so a base document always precedes its derivatives.

Also in this PR:

- `in-session-documents.js` passed `documentSortKey` straight to `_.sortBy`, so its second parameter was lodash's array index rather than the options object. `locale` was always `undefined` and titles sorted by their English text whatever the UI language. Now passes `{ locale }` explicitly.
- `document-id.js` and `schedules/index-id.js` use the same separator, where a variable-width field (`group`, room title) sits mid-key. Hardening only, no visible reordering expected.
- `agenda.js` has the same shape but not the bug (all fields before the last are fixed width) and is untouched.

## Testing

Ran `documentSortKey` from `HEAD` and from the branch over the same input. The annexes are the only thing that moved; `/1`, `/1/REV1`, `/1/ADD1`, `/2` and `INF/7` before `INF/10` are byte-identical. `npm run build` succeeds.

Still to check in a running app before this leaves draft:

- [ ] Full document list on `/meetings/sbstta-27` vs `master` - nothing else may reorder
- [ ] Pin/unpin re-sort, and the print-smart checkout dropdown
- [ ] In-session view in English (unchanged) and French (titles now sort by French title - this one *will* differ)
- [ ] Document management and schedules pages - no visible change expected

## User-Facing Changes

A document now appears immediately before its own annexes, revisions and addenda, instead of after them.

## Summary

No Jira ticket - reported directly. The repo is at rollout phase 0, where the pre-existing-ticket rule does not yet apply.
