### PR TITLE
fix(UI): Link-only documents and deep-linkable document tabs

### DIFF
--- a/app/views/meetings/documents/documents.html
+++ b/app/views/meetings/documents/documents.html
@@ -147,7 +147,7 @@
     <!-- Tab panes -->
     <div class="tab-content" style="padding-top:5px">
 
-        <div ng-repeat="type in documentsCtrl.tabs track by type.code" ng-class="{ active: (documentsCtrl.currentTab==type.code || documentsCtrl.noTabs) }" role="tabpanel" class="tab-pane" id="{{::type.code}}">
+        <div ng-repeat="type in documentsCtrl.tabs track by type.code" ng-class="{ active: (documentsCtrl.currentTab==type.code || documentsCtrl.noTabs) }" role="tabpanel" class="tab-pane" id="tab-{{::type.code}}">
 
             <div ng-if="type.loaded || documentsCtrl.currentTab==type.code || documentsCtrl.noTabs">
 

--- a/app/views/meetings/documents/documents.js
+++ b/app/views/meetings/documents/documents.js
@@ -62,7 +62,7 @@ export { default as template } from './documents.html';
         _ctrl.showMeeting = showMeeting===undefined ? true : !!showMeeting;
         _ctrl.statsMode = null;
         _ctrl.uploadStatement = false;
-        _ctrl.sort = $location.hash() == 'agenda' ? 'agenda' : 'document';
+        _ctrl.sort = $location.search().sort == 'agenda' ? 'agenda' : 'document';
         _ctrl.tabs = [];
         _ctrl.switchTab  = switchTab;
         _ctrl.hideAlert  = hideAlert;
@@ -77,7 +77,7 @@ export { default as template } from './documents.html';
         _ctrl.selectedDocuments = () => allDocuments.filter(o => o.selected);
 
         $scope.$watch('documentsCtrl.sort', function(s){
-            $location.hash(s=='agenda' ? 'agenda' : null);
+            $location.search('sort', s=='agenda' ? 'agenda' : null);
         });
 
         $scope.$watch('$root.deviceSize', updateMaxTabCount);
@@ -542,6 +542,9 @@ export { default as template } from './documents.html';
         //
         //==============================
         function switchTab(tab, extra) {
+
+            if(tab) $location.hash(tab.code); // only an explicit selection owns the fragment
+
             $scope.$applyAsync(function(){
                 switchTabDirect(tab, extra);
             });
@@ -605,8 +608,11 @@ export { default as template } from './documents.html';
                 $scope.focusDocumentId = result?.document?._id;
                 tab = result?.tab;
 
-                $location.search({doc:null});
+                $location.search('doc', null);
             }
+
+            if(!tab)
+                tab = findTab($location.hash());
 
             hardTab = hardTab || !!tab;
 

--- a/app/views/meetings/documents/meeting-document.html
+++ b/app/views/meetings/documents/meeting-document.html
@@ -41,7 +41,7 @@
                             <span  ng-bind="document.statementSource.session"></span>
                         </span>
                     
-                        <a ng-href="{{document.symbol ? null : document.url}}" style="color: inherit;">
+                        <a ng-href="{{titleUrl}}" style="color: inherit;">
                             {{::document.title|lstring}}
                         </a> 
 
@@ -93,14 +93,19 @@
             <document-files ng-if="!viewOnly" files="document.files"></document-files>
         </td>
 
-        <td ng-style="::{ visibility: (enableSelection && downloadble ? 'visible' : 'hidden') }" class="hidden-print" ng-click="document.selected=!document.selected;" style="width:20px; position:relative;">
+        <td class="hidden-print" ng-click="document.selected=!document.selected;" style="width:20px; position:relative; text-align:left;">
             <div class="hidden-xs animated rubberBand  printsmart-help-document-selector" style="position:absolute;left:-30px;margin-top:5px">
                 <i class="fa fa-arrow-right text-info" style="font-size:2em"></i>
             </div>
             <div class="hidden-sm hidden-md hidden-lg animated rubberBand printsmart-help-document-selector" style="position:absolute;right:-3px;margin-top:10px">
                 <i class="fa fa-arrow-left text-info" style="font-size:1.2em"></i>
             </div>
-            <checkbox ng-style="::{ visibility: (downloadble ? 'visible' : 'hidden') }" ng-model="document.selected" style="font-size:2em" ng-class="::{'text-info':document.metadata.printable, 'text-muted':!document.metadata.printable }"></checkbox>
+
+            <checkbox ng-if="enableSelection && downloadble" ng-model="document.selected" style="font-size:2em" class="text-info"></checkbox>
+
+            <a ng-if="linkOnly" ng-href="{{titleUrl}}" target="_blank" ng-click="$event.stopPropagation();" class="text-info" style="font-size:2em">
+                <i class="fa fa-fw fa-external-link" style="text-align:left;"></i>
+            </a>
         </td>
     </tr>
 </table>

--- a/app/views/meetings/documents/meeting-document.js
+++ b/app/views/meetings/documents/meeting-document.js
@@ -40,6 +40,8 @@ import AgendaItem from '~/components/meetings/sessions/agenda-item.vue'
                 $scope.viewOnly       = $rootScope.viewOnly
                 $scope.breakSymbol    = breakSymbol;
                 $scope.downloadble    = canDownload();
+                $scope.linkOnly       = isLinkOnly();
+                $scope.titleUrl       = titleUrl();
                 $scope.LANGUAGES      = LANGUAGES
                 $scope.vueOptions = { components: { copyLink, AgendaItem } } ;
                 $scope.dateFormat = ()=>$scope.showStatistics=='full' ? 'yyyy-MM-dd HH:mm' : 'yyyy-MM-dd';
@@ -56,6 +58,24 @@ import AgendaItem from '~/components/meetings/sessions/agenda-item.vue'
                 //==============================
                 function canDownload() {
                     return $scope.document.files && $scope.document.files.length && _.some($scope.document.files, function(f) { return f.type!=ONLINE; });
+                }
+
+                //==============================
+                //
+                //==============================
+                function isLinkOnly() {
+                    return Boolean($scope.document.files && $scope.document.files.length && !$scope.downloadble);
+                }
+
+                //==============================
+                // With nothing to download, the target is the link itself
+                //==============================
+                function titleUrl() {
+
+                    if($scope.linkOnly)
+                        return $scope.document.files[0].url;
+
+                    return $scope.document.symbol ? null : $scope.document.url;
                 }
 			}
 		};


### PR DESCRIPTION
Two small fixes to the meeting-documents view.

**Link-only documents** - documents whose only files are `text/html` have nothing to download, so the internal document URL was a dead end. The title now links to the first file, and the selection column shows an external-link icon in place of the unusable print-smart checkbox.

**Deep-linkable tabs** - the URL fragment now names the active tab (`/COP-16#statement` opens the Statements tab), written only on an explicit tab click so programmatic switches leave the URL alone. Agenda sorting moves from `#agenda` to `?sort=agenda` (no fallback for the old fragment), and clearing `?doc=` no longer wipes the rest of the query string.