### PR TITLE
fix(UI): No website links in the view-only document list

### DIFF
--- a/app/views/meetings/documents/meeting-document.html
+++ b/app/views/meetings/documents/meeting-document.html
@@ -11,7 +11,7 @@
                     </div>
 
                     <div ng-if="::document.symbol" title="{{::document.publishedOn|date:'yyyy-MM-dd':'UTC'}}">
-                        <a ng-href="{{::document.url}}" style="color:inherit" ng-switch="::document.type">
+                        <a ng-href="{{::symbolUrl}}" target="_blank" style="color:inherit" ng-switch="::document.type">
 
                             <strong ng-switch-when="decision">
                                 Decision <span class="break-word">{{::document.symbol}}</span>
@@ -31,7 +31,7 @@
                             </strong>
                         </a>
 
-                        <span ng-if="document.url">
+                        <span ng-if="!viewOnly && document.url">
                             <copy-Link ng-vue="vueOptions" :link="document.url"></copy-Link>
                         </span>
                     </div>
@@ -41,11 +41,11 @@
                             <span  ng-bind="document.statementSource.session"></span>
                         </span>
                     
-                        <a ng-href="{{titleUrl}}" style="color: inherit;">
+                        <a ng-href="{{::titleUrl}}" target="_blank" style="color: inherit;">
                             {{::document.title|lstring}}
                         </a> 
 
-                        <span ng-if="!document.symbol && document.url">
+                        <span ng-if="!viewOnly && !document.symbol && document.url">
                             <copy-Link ng-vue="vueOptions" v-if="!document.symbol && document.url" :link="document.url"></copy-Link>
                         </span>
                     </div>

--- a/app/views/meetings/documents/meeting-document.js
+++ b/app/views/meetings/documents/meeting-document.js
@@ -41,6 +41,7 @@ import AgendaItem from '~/components/meetings/sessions/agenda-item.vue'
                 $scope.breakSymbol    = breakSymbol;
                 $scope.downloadble    = canDownload();
                 $scope.linkOnly       = isLinkOnly();
+                $scope.symbolUrl      = symbolUrl();
                 $scope.titleUrl       = titleUrl();
                 $scope.LANGUAGES      = LANGUAGES
                 $scope.vueOptions = { components: { copyLink, AgendaItem } } ;
@@ -68,12 +69,26 @@ import AgendaItem from '~/components/meetings/sessions/agenda-item.vue'
                 }
 
                 //==============================
+                // The symbol is not clickable in view-only
+                //==============================
+                function symbolUrl() {
+
+                    if($scope.viewOnly)
+                        return '';
+
+                    return $scope.document.url;
+                }
+
+                //==============================
                 // With nothing to download, the target is the link itself
                 //==============================
                 function titleUrl() {
 
                     if($scope.linkOnly)
                         return $scope.document.files[0].url;
+
+                    if($scope.viewOnly)
+                        return '';
 
                     return $scope.document.symbol ? null : $scope.document.url;
                 }


### PR DESCRIPTION
In the mobile-app embed (`?viewOnly`), a document symbol or title linking to the website is a dead end - the embed has no way back. Both now render without an `href`, and the copy-link button is hidden. Link-only documents keep their external-link icon, which is the intended way out.

Document links also open in a new tab now, in the regular view as well.