### PR TITLE
feat(UI): Filter statement agenda items by open early-submission sessions

### DIFF
--- a/app/components/meetings/upload-statement-dialog.vue
+++ b/app/components/meetings/upload-statement-dialog.vue
@@ -169,11 +169,16 @@
 <script>
 import $    from 'jquery';
 import i18n from './locales.js'
-import Api  from './api.js'
+import Api, { mapObjectId }  from './api.js'
 import remapCode  from './sessions/re-map.js'
 import { detectFilenameLanguage } from '~/util/language-detect.js'
 
 const captchaSiteKeyV2 = (document && document.documentElement.attributes['captcha-site-key-v2'].value);
+
+// Registration sometimes runs on a remapped meeting record - match either id.
+function remappedIds({ _id }) {
+    return [...new Set([_id, remapCode(_id)])];
+}
 
 export default {
     name: 'uploadStatement',
@@ -270,12 +275,19 @@ export default {
 
             this.meetings = this.meetings.filter(o=>o.uploadStatement);
 
-            // Only allow agenda items that are configured for statement submission
-            // If none are configured, allow all agenda items
-            this.meetings.filter(({ statementAgendaItems })=>statementAgendaItems?.length)
-                         .forEach(({ agenda, statementAgendaItems }) => {
-                            agenda.items = agenda.items.filter(i => statementAgendaItems.includes(i.item));
-                         })
+            // Advance submissions are restricted to the agenda items whose early-submission
+            // session is open right now; with none open, every agenda item stays available.
+            const openSessions = await this.openEarlySubmissionSessions();
+
+            this.meetings.forEach(meeting => {
+                const ids   = remappedIds(meeting);
+                const items = openSessions.filter(s => s.meetingIds?.some(id => ids.includes(id)))
+                                          .map(s => s.agendaItem)
+                                          .filter(item => item != null);
+
+                if(items.length)
+                    meeting.agenda.items = meeting.agenda.items.filter(i => items.includes(i.item));
+            })
 
             if(this.filterByMeetingAgenda){
                 const filterMeetings = Object.keys(this.filterByMeetingAgenda);
@@ -290,6 +302,25 @@ export default {
             }
 
             try { grecaptcha.reset(); } catch(e) {}
+        },
+
+        // The window and the projection are both pushed to the server - only open sessions come
+        // back, carrying just what the agenda-item filter reads.
+        async openEarlySubmissionSessions(){
+
+            const ids = [...new Set(this.meetings.flatMap(remappedIds))];
+
+            if(!ids.length) return [];
+
+            const now = new Date().toISOString();
+            const q   = {
+                earlySubmission : true,
+                meetingIds      : { $in: ids.map(mapObjectId) },
+                date            : { $lte: { $date: now } },
+                cutoffDate      : { $gte: { $date: now } },
+            };
+
+            return await this.api.querySessions({ q, f: { meetingIds: 1, agendaItem: 1 } }) || [];
         },
 
         open()  { this.openDialog(true) },


### PR DESCRIPTION
The statement-upload dialog narrowed its "Agenda Item" list with the static `meeting.statementAgendaItems` whitelist - maintained by hand elsewhere, and blind to whether the advance-submission window was open.

It now derives the list from the early-submission sessions that are open at the moment the dialog loads (`date <= now <= cutoffDate`). With none open, every agenda item stays available - same fallback as before when no whitelist was configured. `meeting.statementAgendaItems` is no longer read.

The window test and a `{ meetingIds, agendaItem }` projection are pushed into the query, so the payload drops from ~8 KB of full session documents to ~1.2 KB, and to `[]` once the window closes - it matters on the venue network.

## User-Facing Changes

While an advance-submission window is open, the dropdown lists exactly the agenda items that have an open session. Once every window has closed, the full agenda is selectable again - so where a meeting also had a whitelist, its previously hidden items reappear after the cutoff.

## Testing

Verified in the running app (headless Chrome against `api.cbddev.xyz`), reading the rendered `<select>` and the network response:

| scenario                                          | dropdown                                    | sessions request    |
| ------------------------------------------------- | ------------------------------------------- | ------------------- |
| SBI-07 `/meetings/SBI-07/documents`, window open  | 3, 4(a), 4(b), 5-14 (13 items; no 1, 2, 4)  | 13 rows, 1221 bytes |
| SBSTTA-28, cutoff passed 26 Jul                   | all 13 items incl. 1, 2, 4 (fallback)       | 0 rows, 4 bytes     |
| `/conferences/nairobi-2026/schedules`, 2 meetings | SBI-07 => 3, 4(a), 4(b), 5                  | 1 request, both ids |

The conference case confirms the schedule row's own `filter-by-meeting-agenda` still intersects on top, and that one request covers every loaded meeting id.

Not exercised: the submit path itself is untouched, so no test statement was pushed into the dev system. `slot.earlySessionOpen` remains the server-side authority at commit time; this change only shapes the dropdown.