### PR TITLE
fix(UI): (DEV-1087) Fix decision edit screen

### DIFF
--- a/app/views/decisions/edit.html
+++ b/app/views/decisions/edit.html
@@ -275,8 +275,8 @@
                             <div ng-repeat="node in decision.nodes">
                                 <edit-element ng-vue="vueOptions" :decision-id="decision._id" :node="node"
                                     :comments="comments" :selected-node="selectedNode" :allow-add-nodes="allowAddNodes"
-                                    @update:selected-node="updateSelectedNode" @change="updateDecision"
-                                    @edit-comment="editComment" />
+                                    @update:selected-node="updateSelectedNode($event)" @change="updateDecision()"
+                                    @edit-comment="editComment($event)" />
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
### General description:
- Update the `updateSelectedNode` function to pass the `$event` value to it, which was the causing the edit window to fail to load.

### Testing instructions:
- Open http://localhost:2000/decisions/cop/16/01/edit.
- Select a paragraph.
- The edit window show open.

### Jira Ticket:
CIR-1087: https://scbd.atlassian.net/browse/DEV-1087