### PR TITLE
feat(UI): Allow disabling PDF generation for uploaded files

### DIFF
--- a/app/views/meetings/documents/management/document-id.html
+++ b/app/views/meetings/documents/management/document-id.html
@@ -632,6 +632,9 @@
     <pre ng-if="editCtrl.error" class="alert alert-danger">{{editCtrl.error|json}}</pre>
 
     <div class="pull-right" role="group" aria-label="..." style="margin-bottom:10px">
+      <label class="form-check-label" style="margin-right:15px" title="Generate a PDF rendition of the uploaded files">
+        <input ng-disabled="uploading" type="checkbox" ng-model="editCtrl.generatePdf"> Generate PDF
+      </label>
       <button ng-disabled="uploading || !editCtrl.document._id" type="button" class="btn btn-danger"  ng-click="editCtrl.del()">Delete</button>
       &nbsp;&nbsp;
       <button ng-disabled="uploading || editCtrl.duplicates.length" type="button" class="btn btn-primary" ng-click="editCtrl.save()">Save</button>

--- a/app/views/meetings/documents/management/document-id.js
+++ b/app/views/meetings/documents/management/document-id.js
@@ -85,6 +85,7 @@ export { default as template } from './document-id.html';
         _ctrl.computeStatementDate       = computeStatementDate;
         _ctrl.addLink                    = addLink;
         _ctrl.documentLink = { language: 'en' }
+        _ctrl.generatePdf  = true;
         _ctrl.type_natures = [ ...type_natures ]
 
         $scope.$watch('editCtrl.document.type_nature', applyTypeNature);
@@ -342,7 +343,7 @@ export { default as template } from './document-id.html';
                 });
 
                 var newQ = _.map(filesToCreate, function(f){
-                    return $http.post('/api/v2016/documents/'+docId+'/files', { url : f.url, generatePdf: true, language:f.language });
+                    return $http.post('/api/v2016/documents/'+docId+'/files', { url : f.url, generatePdf: !!_ctrl.generatePdf, language:f.language });
                 });
 
                 return $q.all(delQ.concat(newQ));


### PR DESCRIPTION
Previously, PDF renditions were always generated for uploaded files. This change introduces a user interface control to allow users to opt out of PDF generation during the upload process, with the default remaining enabled.
